### PR TITLE
Documentation / Tailoring File Build Automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 benchmarks/*.xml
 benchmarks/ubuntu2004/checks/sce/*.sh
-benchmarks/LICENSE
+benchmarks/ComplianceAsCode-LICENSE
 doc/man7/*.7
 doc/man8/*.8
 debian/files

--- a/README.build
+++ b/README.build
@@ -4,6 +4,15 @@ built. This README file contains information on how to execute these steps.
 Prerequisite: build the CaC project
 
 
+METHOD 1: FULLY SCRIPTED
+========================
+1. Modify the configuration variables in tools/build_config.ini to match your paths and desired settings.
+2. Run tools/build.py -- no arguments necessary.
+3. Package the project as a deb using your preferred tooling.
+
+
+METHOD 2: LESS-AUTOMATED
+========================
 
 * STEP 1. Update the rules
 After you fetch the CaC-based usg project from the git repo, you need to copy

--- a/templates/doc/man7/usg-cis.md
+++ b/templates/doc/man7/usg-cis.md
@@ -1,0 +1,110 @@
+% USG-CIS(7) usg-benchmarks-<<USG_BENCHMARKS_ALTERNATIVE_PLACEHOLDER>> <<USG_BENCHMARKS_VERSION_PLACEHOLDER>>
+% Richard Maciel Costa <richard.maciel.costa@canonical.com>
+% <<DATE_PLACEHOLDER>>
+
+# NAME
+usg-cis - Information on CIS profiles implementation
+
+# INTRODUCTION
+As mentioned in the **usg-rules**(8) man page, four CIS profiles are available to be audited/applied: **cis_level1_server**, **cis_level2_server**, **cis_level1_workstation** and **cis_level2_workstation**
+
+This man page provides additional information on all four and explain how to customize some variables in order to properly match the CIS requirements.
+
+Last, this man page explains the limitations of the CIS profiles.
+
+# PROFILES LEVELS AND TARGETS
+This section provides basic explanation on levels and targets, For a through explanation, refer to the CIS benchmark document.
+
+## Profiles Levels
+The CIS benchmark and this implementation provides 2 levels of profiles: level 1 and level 2.  
+As stated in the CIS benchmark specification, level 2 rules "may negatively inhibit the utility or performance of the technology". On the
+other hand, level 1 rules are generally safe to use.
+
+That means level 1 profiles have smaller usability impact than their level 2 counterpart. However, level 2 are considered stricter, from the security standpoint, thus provide additional security.
+
+However, there is one exception to this: rule 5.4.1.4 (Ensure inactive password lock is 30 days or less) applies to all login accounts, including the ones
+with sudo permissions.
+
+Hence, if there is a single account with sudo permissions and that account gets locked, this can lead to a situation where the administrator account is not
+accessible, since, by default, the root user is locked in Ubuntu.
+
+Also, note that level 2 profiles are an extension of level 1 profiles: **all rules applied on level 1 are also applied on level 2**.
+
+## Profiles Targets
+This is self-explanatory: server profiles are made for Canonical Ubuntu Server images, while Workstation profiles are made for Workstation images, which generally implies the use of a graphical interface.
+
+# CUSTOMIZING VARIABLES AFFECTING THE CIS PROFILES IMPLEMENTATIONS
+Some rules can be fine-tuned by changing their variables. However, CIS benchmarks provides some variables with phony parameters which **must be customized** so the hardening scripts can be properly applied and the audit can properly check them.
+
+For additional information on variables, check the **usg-variables**(7) man page.
+
+See the **usg**(8) man page to get information on how to use tailoring files to change the value of variables.
+
+## Rules that must be customized
+The list of variables below contains a brief explanation of the variables which *must be customized* and what rules they are related to.
+
+### Rule 1.5.1 - var\_grub2\_user, var\_grub2\_passwd\_hash
+Above variables are used to set the Grub2 user and password hash. Rule 1.5.1 uses that information to prevent changes to the grub2 entries during the bootloader execution.
+
+If the var\_grub2\_passwd\_hash value is left with the default value '\*', then no password will be set to the bootloader.
+
+To generate the hash value, use the command `grub_mkpasswd_pbkdf2`
+
+### Rule 1.5.3 - var\_root\_passwd\_hash
+This variable holds the hash which will be set into the /etc/shadow entry for the root user. In order to create this hash, use the command below:
+
+`# openssl passwd -6`
+
+and type the password. Copy the generated hash to the value of the aforementioned variable.
+
+If that variable is left with the default value, the **usg** tool **will not set the root password** and the audit will fail if there is not a root password available.
+
+### Rule 5.2.17 - var\_sshd\_allow\_users\_valid, var\_sshd\_allow\_groups\_valid, var\_sshd\_deny\_users\_valid, var\_sshd\_deny\_groups\_valid
+These variables are used to set the ssh server parameters AllowUsers, AllowGroups, DenyUsers, DenyGroups, respectively, which allows an administrator to restrict user/group access to ssh remote access.
+
+The value must be a comma-separated list of users (or groups). If the variables are left with the default value, the **usg** too **will not include those parameters in the ssh server config file**, to avoid lockups.
+
+Check the ssh server man page to get more information on the parameters.
+
+## Some other interesting rules for customizing
+
+### Rule 2.2.1.3 - var\_multiple\_time\_servers
+This variable contains the list of time servers which the chosen time service will synchronize to.
+
+The value must be a comma-separated list of servers. The default values are the safe ones used by Canonical on Ubuntu.
+
+### Rule 5.3.1 - var\_password\_pam\_minlen, var\_password\_pam\_minclass, var\_password\_pam\_dcredit, var\_password\_pam\_ucredit, var\_password\_pam\_ocredit, var\_password\_pam\_lcredit, var\_password\_pam\_retry
+These variables are used to set the password creation parameters of the pam\_pwquality module. The names of the variables reflect those parameters.
+
+Default values are according to the CIS benchmark.
+
+Check the pam\_pwquality module man page for more information on the parameters.
+
+# RULES LIMITATIONS
+## Rule 1.1.10 - partition\_for\_var
+## Rule 1.1.11 - partition\_for\_var\_tmp
+## Rule 1.1.15 - partition\_for\_var\_log
+## Rule 1.1.16 - partition\_for\_var\_log\_audit
+## Rule 1.1.17 - partition\_for\_home
+## Rule 3.5.3.2.1 - iptables\_default\_deny
+## Rule 3.5.3.3.1 - ip6tables\_default\_deny
+## Rule 4.2.3 - all\_logfile\_permissions
+## Rule 4.4 - ensure\_logrotate\_permissions
+Current version of the benchmark only provides the audit check operation for those rules.
+
+There is no fix implemented, so they must be fixed manually!
+
+See the benchmark reference on the *INTERNET RESOURCES* section for information on how to apply the fixes.
+
+# INTERNET RESOURCES
+Ubuntu 20.04 CIS Benchmark: https://workbench.cisecurity.org/benchmarks/5288
+
+# SEE ALSO
+**usg**(8), **usg-rules**(7), **usg-variables**(7)
+
+# COPYRIGHT
+Copyright <<YEAR_PLACEHOLDER>> Canonical Limited. All rights reserved.
+
+The implementation of CIS rules, profiles, scripts, and other assets are based on the ComplianceAsCode open source project (https://www.open-scap.org/security-policies/scap-security-guide).
+
+ComplianceAsCode's license file can be found in the /usr/share/ubuntu-scap-security-guides/benchmarks directory.

--- a/templates/doc/man7/usg-disa-stig.md
+++ b/templates/doc/man7/usg-disa-stig.md
@@ -1,0 +1,106 @@
+% USG-DISA-STIG(7) usg-benchmarks-<<USG_BENCHMARKS_ALTERNATIVE_PLACEHOLDER>> <<USG_BENCHMARKS_VERSION_PLACEHOLDER>>
+% Richard Maciel Costa <richard.maciel.costa@canonical.com>
+% <<DATE_PLACEHOLDER>>
+
+# NAME
+usg-disa-stig - Information on DISA-STIG implementation
+
+# INTRODUCTION
+As mentioned in the **usg-rules**(8) man page, a single DISA-STIG profile is available to be audited/applied: **stig**
+
+This man page explains the limitations of some rules which compose the stig profile.
+
+# CUSTOMIZING VARIABLES AFFECTING THE STIG BENCHMARK IMPLEMENTATIONS
+Some rules can be fine-tuned by changing their variables. However, the STIG benchmark provides some variables with phony parameters which **must be customized** so the hardening scripts can be properly applied and the audit can properly check them.
+
+For additional information on variables, check the **usg-variables**(7) man page.
+
+See the **usg**(8) man page to get information on how to use tailoring files to change the value of variables.
+
+## Rules that must be customized
+The list of variables below contains a brief explanation of the variables which *must be customized* and what rules they are related to.
+
+### Rule id: var\_audispd\_remote\_server
+#### Title: Remote server for audispd to send audit records
+#### Description:
+
+```
+The setting for remote_server in /etc/audisp/audisp-remote.conf
+```
+
+## Rules limitations
+A few rules provided by the stig profile require manual fix. 
+
+In addition, currently the rule *permission\_local\_var\_log* is unable to prevent new log files being created with permissions that violate the DISA-STIG requirements.
+
+Follow a list of the rules below which matches one of the cases above:
+
+### Rule id: auditd\_offload\_logs
+#### Title: Offload audit Logs to External Media
+#### Description:
+
+```
+Offloading is a common process in information systems with limited audit storage capacity.
+NOTE: This script is not provided by default as different consumers have different needs.
+
+Check if there is a script in the "/etc/cron.weekly" directory that offloads audit data:
+# sudo ls /etc/cron.weekly
+audit-offload 
+```
+
+### Rule id: chronyd\_or\_ntpd\_set\_maxpoll
+#### Title: Configure Time Service Maxpoll Interval
+#### Description:
+
+```
+The maxpoll should be configured in /etc/ntp.conf or
+/etc/chrony/chrony.conf to continuously poll time servers. To configure
+maxpoll in /etc/ntp.conf or /etc/chrony/chrony.conf
+add the following after each `server` entry:
+maxpoll
+
+NOTE: The DISA-STIG rule currently does not support `pool` or `peer` entries.
+```
+
+### Rule id: permission\_local\_var\_log
+#### Title:
+#### Description:
+
+```
+This rule will enforce a permission of 0640 for files inside the /var/log directory when its audit process runs.
+However, any change made after the audit process ends potentially can put the system in an uncompliant-state
+with regard to that rules.
+```
+
+### Rule id: is\_fips\_mode\_enabled
+#### Title: Verify '/proc/sys/crypto/fips\_enabled' exists
+#### Description:
+
+```
+This rule will verify if the system is in FIPS mode.
+A manual fix is required in case it is not.
+For more informations on how to run the system in FIPS-140-2 mode, please see
+https://ubuntu.com/security/certifications/docs/fips-enablement
+```
+
+### Rule    package\_mfetp\_installed
+#### Title: Install Endpoint Security for Linux Threat Prevention
+#### Description:
+
+```
+This rule requires a third-party software to be installed.
+A manual fix is required if the software is not available.
+```
+
+# INTERNET RESOURCES
+Ubuntu 20.04 STIG Benchmark: https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/U\_CAN\_Ubuntu\_20-04\_LTS\_V1R1\_STIG.zip
+
+# SEE ALSO
+**usg**(8), **usg-rules**(7), **usg-variables**(7)
+
+# COPYRIGHT
+Copyright <<YEAR_PLACEHOLDER>> Canonical Limited. All rights reserved.
+
+The implementation of DISA-STIG rules, profiles, scripts, and other assets are based on the ComplianceAsCode open source project (https://www.open-scap.org/security-policies/scap-security-guide).
+
+ComplianceAsCode's license file can be found in the /usr/share/ubuntu-scap-security-guides/benchmarks directory.

--- a/templates/doc/man7/usg-rules.md
+++ b/templates/doc/man7/usg-rules.md
@@ -1,0 +1,19 @@
+% USG-RULES(7) usg-benchmarks-<<USG_BENCHMARKS_ALTERNATIVE_PLACEHOLDER>> <<USG_BENCHMARKS_VERSION_PLACEHOLDER>>
+% Richard Maciel Costa <richard.maciel.costa@canonical.com>
+% <<DATE_PLACEHOLDER>>
+
+# NAME
+usg-rules - usg rules list and description
+
+# LIST OF RULES AND THEIR DESCRIPTIONS
+<<USG_MAN_RULES_PLACEHOLDER>>
+
+# SEE ALSO
+**usg**(8)
+
+# COPYRIGHT
+Copyright <<YEAR_PLACEHOLDER>> Canonical Limited. All rights reserved.
+
+The implementation of DISA-STIG rules, CIS rules, profiles, scripts, and other assets are based on the ComplianceAsCode open source project (https://www.open-scap.org/security-policies/scap-security-guide).
+
+ComplianceAsCode's license file can be found in the /usr/share/ubuntu-scap-security-guides/benchmarks directory.

--- a/templates/doc/man7/usg-variables.md
+++ b/templates/doc/man7/usg-variables.md
@@ -1,0 +1,19 @@
+% USG-VARIABLES(7) usg-benchmarks-<<USG_BENCHMARKS_ALTERNATIVE_PLACEHOLDER>> <<USG_BENCHMARKS_VERSION_PLACEHOLDER>>
+% Richard Maciel Costa <richard.maciel.costa@canonical.com>
+% <<DATE_PLACEHOLDER>>
+
+# NAME
+usg-variables - usg variables list and description
+
+# LIST OF VARIABLES AND THEIR DESCRIPTIONS
+<<USG_MAN_VARIABLE_PLACEHOLDER>>
+
+# SEE ALSO
+**usg**(8)
+
+# COPYRIGHT
+Copyright <<YEAR_PLACEHOLDER>> Canonical Limited. All rights reserved.
+
+The implementation of DISA-STIG rules, CIS rules, profiles, scripts, and other assets are based on the ComplianceAsCode open source project (https://www.open-scap.org/security-policies/scap-security-guide).
+
+ComplianceAsCode's license file can be found in the /usr/share/ubuntu-scap-security-guides/benchmarks directory.

--- a/templates/doc/man8/usg.md
+++ b/templates/doc/man8/usg.md
@@ -1,0 +1,239 @@
+% USG(8) usg <<USG_BENCHMARKS_VERSION_PLACEHOLDER>>
+% Richard Maciel Costa <richard.maciel.costa@canonical.com>, Nikos Mavrogiannopoulos <nikos.mavrogiannopoulos@canonical.com>
+% <<DATE_PLACEHOLDER>>
+
+# NAME
+usg - Audit and remediation tool for security benchmarks compliance automatization
+
+# SYNOPSYS
+**usg** *command* [*command_opts*] [*command_args*]
+
+**usg** **audit** [**`--tailoring-file` filename** | **profile**]
+
+**usg** **fix** [**`--tailoring-file` filename** | **profile**]
+
+**usg** **generate-fix** [**`--output` filename**] [**`--tailoring-file` filename** | **profile**]
+
+**usg** **generate-tailoring** **profile** **filename**
+
+Available profiles: *cis_level1_server* | *cis_level2_server* | *cis_level1_workstation* | *cis_level2_workstation* | *stig*
+
+# DESCRIPTION
+**usg**, short for Ubuntu Security Guide, is a tool to audit and comply with security guides such as CIS and DISA-STIG.
+The tool is designed to carry the basic operations needed to maintain and audit compliance on a system, while using the powerful OpenSCAP engine.
+
+**usg** provides four commands, **audit**, **fix**, **generate-fix** and **generate-tailoring**, which are described in the **commands** section.
+
+Running **usg** without any command line parameters cause **usg** to display its usage message.
+
+# COMMANDS
+**usg audit**
+: Run the audit tests for the provided profile. That is, it checks if the profile is already applied on the system or not. The output is written to both an user-friendly HTML file and a file containing extensive report. See the *FILES* section for more information.
+
+**usg fix**
+: Run the audit tests for the given profile and remediate when the system doesn't meet the test. This command modifies the running system and **it requires a reboot after it finishes, to full apply the fixes!**. Use this command on a recently provisioned system or already installed applications may not function properly.
+
+**usg generate-fix**
+: Generates a Bash script containing commands to setup the system to comply with the profile or to the tailoring file provided.
+
+**usg generate-tailoring**
+: Generates a tailoring file based on the provided profile. This tailoring file serves many purposes. It allows to optimize the compliance of the system by filling the necessary variables, comply with a subset of the profile rules, as well as to fix to a specific profile version.
+
+# OPTIONS
+**`--help`**
+: Displays the usage message
+
+**`--output`**
+: Filepath of the remediate file generated. Only works when the command is **generate-fix**.
+
+**`--tailoring-file`**
+: Sets the path to the tailoring-file, which contains a set of rules-selectors and value-customization elements, effectively letting the user customize the rules which will be applied. If that option is used, then the **profile** parameter is **ignored**! This option can be used for both commands. Check the **Tailoring Files** section for more info on them.
+
+# EXAMPLES
+1. audit system using DISA-STIG profile
+
+    `# usg audit stig`
+
+2. audit and remediate system using CIS Level 1 Server profile
+
+    `# usg fix cis_level1_server`
+
+3. generate tailoring file based on profile cis\_level2\_workstation
+
+    `# usg generate-tailoring cis_level2_workstation /root/cis_level2_workstation-tailoring.xml`
+
+4. generate fix script based on the previous tailoring file
+
+    `# usg generate-fix --output /root/usg_fix_script.sh --tailoring-file /root/cis_level2_workstation-tailoring.xml`
+
+5. generate a default tailoring file for the system based on cis\_level2\_workstation
+
+    `# usg generate-tailoring cis_level2_workstation /etc/usg/default-tailoring.xml`
+
+5. audit and remediate system using the default tailoring file for the system
+
+    `# usg fix`
+
+
+# TAILORING FILES
+**usg** rules are associated with **usg profiles** (and their benchmark counterparts) on XCCDF files used by OpenSCAP, which also contain the parameters used by the rules.
+The XCCDF files, however, are quite verbose and complicated and usg hides the complexity of dealing with them. **Tailoring files** is the way to customize profiles with usg.
+
+A tailoring file is a XML file which contains the list of rules that are used in auditing and fixing with their corresponding parameters.
+
+In practice it can be used to set specific parameters of the audit (e.g., valid groups which can access the machine through ssh, set on variable *var\_sshd\_allow\_users\_valid*, affecting rule *sshd\_configure\_allow\_users*), or customize a general profile to the organization's requirements.
+The XML file is composed of *xccdf:select* and *xccdf:set-value* elements, described below.
+
+## The xccdf:select element
+This element sets if a given **usg rule** will be audited (and/or fixed, depending on the command/options used) or not. So, as an example, if the administrator wants to customize his tailoring file to disable the *sshd\_set\_loglevel\_info\_or\_verbose* rule execution, its associated *xccdf:select* element must be set as below:
+
+```
+<xccdf:select idref="sshd_set_loglevel_info_or_verbose" selected="false"/>
+```
+
+## the xccdf:set-value element
+This element sets a variable associated with a given **usg rule**. The variable will change the way the rule executes in a specific way for that rule. So, as an example, if the administrator wants to customize his tailoring file to change the *var\_sshd\_set\_loglevel* variable to the value 'VERBOSE', its associated *xccdf:set-value* element must be set as below:
+
+```
+<xccdf:set-value idref="var_sshd_set_loglevel">VERBOSE</xccdf:set-value>
+```
+
+For a list of rules and their descriptions, see the **usg-rules** man page.  
+For a list of variables and their descriptions, see the **usg-variables** man page.
+
+## Tailoring files and Benchmark rules
+The **usg-benchmark-\<VERSION\>** package provides 5 tailoring files in its *tailoring* subdirectory inside its installation directory, one for each profile. Those tailoring files are essentially a copy of their respective profiles, containing their respective rules, so an admin can can disable specific ones.
+
+The provided tailoring files also group the *usg rules* according to the benchmark rules they belong to, with the comments pointing to the benchmark rule identifier and its name.
+
+**We strongly recommend using the command generate-tailoring to get a copy of the tailoring file and customize that copy, instead of modifying the original ones**
+
+Note that the *generate-tailoring* command uses the aforementioned original tailoring files to generate new ones.
+
+# BENCHMARKS PACKAGES
+The *usg* tool depends on one or more *usg-benchmarks-\<VERSION\>* packages to be able to execute its operations. The *usg* tool quits with an error message if it detects none.
+
+## Benchmark package version
+The \<VERSION\> suffix is used to provide information regarding changes to the benchmarks bundled into the Benchmarks package. So, the package starts with \<VERSION\> is initially
+set to 1 and this value is increased each time a bundled benchmark receives an upgrade. For instance, the package version 1 contains CIS benchmark version 1.0.0 and DISA-STIG version
+V1R1. Canonical may decide to update CIS benchmark to version 2.0.1, but keep DISA-STIG version V1R1, which will lead to an a new Benchmarks package version 2.
+Note that the Benchmarks package version is not tied to the bundled benchmarks versions!
+
+So, if both *usg-benchmarks-1* and *usg-benchmarks-2* packages are installed, the system will output the following lines when listing the packages:
+
+```
+$ dpkg -l 'usg-benchmarks*'
+ii  usg-benchmarks-1 20.04.10 all          SCAP content for CIS and DISA-STIG Ubuntu Benchmarks
+ii  usg-benchmarks-2 20.04.10 all          SCAP content for CIS and DISA-STIG Ubuntu Benchmarks
+```
+
+As one may see, the benefit of using this approach is to allow installation of more than one Benchmark package. Next section explains how to select a specific Benchmarks package version
+after installation.
+
+In case where **no** usg-benchmarks-\<VERSION\> packages are installed, then **usg** tool issues an error message when executing any of its commands.
+
+## Benchmarks package selection
+The usg-benchmarks-\<VERSION\> packages register themselves upon installation with the Debian alternatives system with the *usg_benchmarks* name. If both *usg-benchmarks-1* and
+*usg-benchmarks-2* packages are installed, listing the Debian alternatives system will output the following lines:
+
+```
+$ update-alternatives --list usg_benchmarks
+/usr/share/ubuntu-scap-security-guides/1
+/usr/share/ubuntu-scap-security-guides/2
+```
+
+Also, the Debian alternatives system displays additional information regarding the current selected Benchmarks package:
+
+```
+$ update-alternatives --display usg_benchmarks
+usg_benchmarks - auto mode
+  link best version is /usr/share/ubuntu-scap-security-guides/1
+  link currently points to /usr/share/ubuntu-scap-security-guides/1
+  ...
+```
+
+In order the benchmarks from version 2, use the following command:
+
+`sudo update-alternatives --config usg_benchmarks`
+
+and set the number associated with version 2 on the selection menu.
+
+For more information on how to use the *update-alternatives* command check the **update-alternatives** man page.
+
+# TAILORING FILES AND BENCHMARKS VERSIONS
+The *benchmark* element of a tailoring file has the attribute href which points to the base XCCDF files which the tailoring file is based upon. Take the
+following snippet of a tailoring file as an example:
+
+```
+<cdf-11-tailoring:Tailoring xmlns:cdf-11-tailoring="http://open-scap.org/page/Xccdf-1.1-tailoring" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" id="xccdf_scap-workbench_tailoring_default">
+  <cdf-11-tailoring:benchmark href="/usr/share/ubuntu-scap-security-guides/1/benchmarks/Canonical_Ubuntu_20.04_Benchmarks-xccdf.xml"/>
+  <cdf-11-tailoring:version time="2021-09-23T14:32:50">1</cdf-11-tailoring:version>
+  <xccdf:Profile id="cis_level1_server_customized" extends="cis_level1_server">
+```
+
+That URL includes the specific version of the Benchmarks package (version 1 in this case).
+
+That information is used by the *usg* tool to verify if the the tailoring file is compatible with the current Benchmarks package selected. This only occurs if they hold the same version.
+
+In the above example the *benchmark* element has the version included in one of the components of the path, so the *usg* tool will only execute operations with that tailoring file
+if *usg_benchmark* points to Benchmarks package version 1.
+
+# FILES
+/etc/usg/default-tailoring.xml
+
+> When this file is present it is treated as the default tailoring file and is read automatically when no profile is given.
+
+/var/lib/usg/usg-results-DATE.xml
+
+> Result file generated by the audit process, containing extensive information on the rules tested and the outcome of each `usg rule` test.
+
+/var/lib/usg/usg-report-DATE.html
+
+> HTML file report containing the rules audited and their results in an user-friendly format.
+
+# ADDITIONAL INFORMATION
+
+## What are Security Technical Implementation Guides or Benchmarks?
+Security Technical Implementation Guides (STIGs), sometimes called security benchmarks, are documents which contain sets of security-oriented rules created with the purpose of helping system administrators harden their systems.
+The scope of the rules can be quite extensive and span both the operating system and all the software installed on it.
+
+Benchmarks, like CIS, create sets of rules for specific environments (like server or workstation environments) and provide additional levels of security (CIS level 2 is safer, but has additional impact on the usability).
+
+## Benchmark rules vs usg rules
+This man page will refer as **benchmark rules** for the rules described in their specific benchmark documents. For instance, Canonical Ubuntu 20.04 CIS 1.0.0 rule 5.6, which is a rule defined in the document of the CIS benchmark for Ubuntu 20.04 version 1.0.0.
+On the other hand, **usg rules** are sets of specific instructions, described in computer languages, used to audit and/or fix a system.  
+A **benchmark rule is implemented by one or more usg rules**.
+
+## What are Profiles?
+Profiles are set of **usg rules** which, together, implement the rules described by a specific benchmark (CIS or STIG). For instance, the profile *cis_level1_server* states that the *usg rules* implement audit and remediation instructions to make a system as compliant as possible with the Ubuntu 20.04 CIS Benchmark, specifically, with its CIS level 1 server set of benchmark rules (which is also called a profile by the CIS).
+
+Note that the DISA-STIG benchmark only has a single profile, because it's thought to run in a broad set of environments.
+
+If you desire to customize the rules which are ran in a given profile or customize their parameters, use the **`--tailoring-file`** option to point **usg** to **Tailoring files**.
+
+Note, however, that if the **tailoring-file** option is not provided, the user **must** provide a profile name for the **usg** tool!
+
+See more info on **Tailoring Files** on the same-name section.
+
+### Additional Info on Profiles
+CIS Profiles (**cis_level1_server**, **cis_level2_server**, **cis_level1_workstation** and **cis_level2_workstation**)
+: Level 1 profiles have smaller usability impact than their level 2 counterparts.
+: Server profiles are made for Canonical Ubuntu Server images, while Workstation profiles are made for Workstation images, which generally implies the use of a graphical interface.
+
+Profiles for DISA-STIG (**stig**)
+: Sole profile for DISA-STIG provides the entire set of rules made for Canonical Ubuntu DISA-STIG benchmark.
+
+For more info on CIS and DISA-STIG, look at the respective benchmark documents.
+
+# INTERNET RESOURCES
+OpenScap: https://www.open-scap.org/
+
+Ubuntu 20.04 CIS Benchmark: https://workbench.cisecurity.org/benchmarks/5288
+
+Ubuntu 20.04 STIG Benchmark: https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/U\_CAN\_Ubuntu\_20-04\_LTS\_V1R1\_STIG.zip
+
+# SEE ALSO
+**usg-rules**(7), **usg-variables**(7), **usg-cis**(7), **usg-disa-stig**(7), **oscap**(8), **update-alternatives**(1)
+
+# COPYRIGHT
+Copyright <<YEAR_PLACEHOLDER>> Canonical Limited. All rights reserved.

--- a/templates/tailoring/cis_level1_server-tailoring.xml
+++ b/templates/tailoring/cis_level1_server-tailoring.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cdf-11-tailoring:Tailoring xmlns:cdf-11-tailoring="http://open-scap.org/page/Xccdf-1.1-tailoring" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" id="xccdf_scap-workbench_tailoring_default">
+  <cdf-11-tailoring:benchmark href="/usr/share/ubuntu-scap-security-guides/<<USG_BENCHMARKS_ALTERNATIVE_PLACEHOLDER>>/benchmarks/Canonical_Ubuntu_20.04_Benchmarks-xccdf.xml"/>
+  <cdf-11-tailoring:version time="<<ISODATETIME_PLACEHOLDER>>">1</cdf-11-tailoring:version>
+  <xccdf:Profile id="cis_level1_server_customized" extends="cis_level1_server">
+    <xccdf:title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 20.04 Level 1 Server Benchmark [CUSTOMIZED]</xccdf:title>
+    <xccdf:description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security
+Ubuntu 20.04 LTS Benchmark, v1.0.0, released 07-21-2020.</xccdf:description>
+<<LEVEL_1_SERVER_TAILORING_PLACEHOLDER>>
+  </xccdf:Profile>
+</cdf-11-tailoring:Tailoring>
+

--- a/templates/tailoring/cis_level1_workstation-tailoring.xml
+++ b/templates/tailoring/cis_level1_workstation-tailoring.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cdf-11-tailoring:Tailoring xmlns:cdf-11-tailoring="http://open-scap.org/page/Xccdf-1.1-tailoring" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" id="xccdf_scap-workbench_tailoring_default">
+  <cdf-11-tailoring:benchmark href="/usr/share/ubuntu-scap-security-guides/<<USG_BENCHMARKS_ALTERNATIVE_PLACEHOLDER>>/benchmarks/Canonical_Ubuntu_20.04_Benchmarks-xccdf.xml"/>
+<cdf-11-tailoring:version time="<<ISODATETIME_PLACEHOLDER>>">1</cdf-11-tailoring:version>
+  <xccdf:Profile id="cis_level1_workstation_customized" extends="cis_level1_workstation">
+    <xccdf:title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 20.04 Level 1 Workstation Benchmark [CUSTOMIZED]</xccdf:title>
+    <xccdf:description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security
+Ubuntu 20.04 LTS Benchmark, v1.0.0, released 07-21-2020.</xccdf:description>
+<<LEVEL_1_WORKSTATION_TAILORING_PLACEHOLDER>>
+  </xccdf:Profile>
+</cdf-11-tailoring:Tailoring>
+

--- a/templates/tailoring/cis_level2_server-tailoring.xml
+++ b/templates/tailoring/cis_level2_server-tailoring.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cdf-11-tailoring:Tailoring xmlns:cdf-11-tailoring="http://open-scap.org/page/Xccdf-1.1-tailoring" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" id="xccdf_scap-workbench_tailoring_default">
+  <cdf-11-tailoring:benchmark href="/usr/share/ubuntu-scap-security-guides/<<USG_BENCHMARKS_ALTERNATIVE_PLACEHOLDER>>/benchmarks/Canonical_Ubuntu_20.04_Benchmarks-xccdf.xml"/>
+  <cdf-11-tailoring:version time="<<ISODATETIME_PLACEHOLDER>>">1</cdf-11-tailoring:version>
+  <xccdf:Profile id="cis_level2_server_customized" extends="cis_level2_server">
+    <xccdf:title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 20.04 Level 2 Server Benchmark [CUSTOMIZED]</xccdf:title>
+    <xccdf:description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security
+Ubuntu 20.04 LTS Benchmark, v1.0.0, released 07-21-2020.</xccdf:description>
+<<LEVEL_2_SERVER_TAILORING_PLACEHOLDER>>
+  </xccdf:Profile>
+</cdf-11-tailoring:Tailoring>
+
+

--- a/templates/tailoring/cis_level2_workstation-tailoring.xml
+++ b/templates/tailoring/cis_level2_workstation-tailoring.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cdf-11-tailoring:Tailoring xmlns:cdf-11-tailoring="http://open-scap.org/page/Xccdf-1.1-tailoring" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" id="xccdf_scap-workbench_tailoring_default">
+  <cdf-11-tailoring:benchmark href="/usr/share/ubuntu-scap-security-guides/<<USG_BENCHMARKS_ALTERNATIVE_PLACEHOLDER>>/benchmarks/Canonical_Ubuntu_20.04_Benchmarks-xccdf.xml"/>
+  <cdf-11-tailoring:version time="<<ISODATETIME_PLACEHOLDER>>">1</cdf-11-tailoring:version>
+  <xccdf:Profile id="cis_level2_workstation_customized" extends="cis_level2_workstation">
+    <xccdf:title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 20.04 Level 2 Workstation Benchmark [CUSTOMIZED]</xccdf:title>
+    <xccdf:description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security
+Ubuntu 20.04 LTS Benchmark, v1.0.0, released 07-21-2020.</xccdf:description>
+<<LEVEL_2_WORKSTATION_TAILORING_PLACEHOLDER>>
+  </xccdf:Profile>
+</cdf-11-tailoring:Tailoring>
+
+

--- a/templates/tailoring/stig-tailoring.xml
+++ b/templates/tailoring/stig-tailoring.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cdf-11-tailoring:Tailoring xmlns:cdf-11-tailoring="http://open-scap.org/page/Xccdf-1.1-tailoring" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" id="xccdf_scap-workbench_tailoring_default">
+  <cdf-11-tailoring:benchmark href="/usr/share/ubuntu-scap-security-guides/<<USG_BENCHMARKS_ALTERNATIVE_PLACEHOLDER>>/benchmarks/Canonical_Ubuntu_20.04_Benchmarks-xccdf.xml"/>
+  <cdf-11-tailoring:version time="<<ISODATETIME_PLACEHOLDER>>">1</cdf-11-tailoring:version>
+  <xccdf:Profile id="stig_customized" extends="stig">
+    <xccdf:title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">DISA-STIG Benchmark [CUSTOMIZED]</xccdf:title>
+    <xccdf:description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the DISA-STIG v.1, rel.1, released 04-06-2021.</xccdf:description>
+<<STIG_TAILORING_PLACEHOLDER>>
+  </xccdf:Profile>
+</cdf-11-tailoring:Tailoring>

--- a/tools/build.py
+++ b/tools/build.py
@@ -1,0 +1,246 @@
+#!/usr/bin/python3
+#
+# Ubuntu Security Guide
+# Copyright (C) 2022 Canonical Limited
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import datetime, subprocess, os, sys, configparser, re, traceback
+
+# This is assumed to be in the same directory as this script.
+tools_directory = os.path.dirname(os.path.realpath(__file__))
+configfile = "%s/build_config.ini"%(tools_directory)
+
+def exit_error(msg):
+    print("Build script exiting with error:\n%s\n"%(msg))
+    traceback.print_exc()
+    sys.exit(1)
+
+def load_config():
+    config=configparser.ConfigParser()
+    if config.read(configfile) == []:
+        exit_error("\
+            Could not open config.ini file.\n\
+            Is this present in the same directory as the script?")
+
+    try:
+        package_version = config["DEFAULT"]["version"]
+    except:
+         exit_error("\
+            \"version\" key is not present in a \"DEFAULT\" section.\n\
+            Has config.ini been malformed?")
+
+    try:
+        alternative_version = config["DEFAULT"]["alternative_version"]
+    except:
+        exit_error("\
+            \"alternate_version\" key is not present in a \"DEFAULT\" section.\n\
+            Has config.ini been malformed?")
+
+    try:
+        target = config["DEFAULT"]["target"]
+    except:
+        exit_error("\
+            \"target\" key is not present in a \"DEFAULT\" section.\n\
+            Has config.ini been malformed?")
+
+    try:
+        usg_directory = config["DEFAULT"]["usg_directory"]
+    except:
+        exit_error("\
+            \"usg_directory\" key is not present in a \"DEFAULT\" section.\n\
+            Has config.ini been malformed?")
+
+    try:
+        cac_directory = config["DEFAULT"]["cac_directory"]
+    except:
+        exit_error("\
+            \"cac_directory\" key is not present in a \"DEFAULT\" section.\n\
+            Has config.ini been malformed?")
+   
+    return package_version, alternative_version, target, usg_directory, cac_directory
+
+def run_ppb(tools_directory, cac_directory, usg_directory):
+    try:
+        ppb_out = subprocess.check_output(\
+            ["%s/pre_package_build.sh"%(tools_directory),\
+            "%s/%s"%(tools_directory, cac_directory),\
+            "%s/%s"%(tools_directory, usg_directory)])
+    except CalledProcessError:
+        exit_error("\
+            pre_package_build.sh returned a non-zero status. Possible failure.\n\
+            %s"%(ppb_out))
+
+def update_alternative_version(usg_path, altver):
+    try:
+        control_file = open("%s/%s/debian/control"%(tools_directory, usg_path), "r")
+    except:
+        exit_error("\
+            debian/control file was unable to be opened for reading.\n\
+            Is \"usg_directory\" key in config.ini wrong?")
+    control_data = control_file.read()
+    control_file.close()
+    
+    try:
+        control_file = open("%s/%s/debian/control"%(tools_directory, usg_path), "w")
+    except:
+        exit_error("\
+            debian/control file was unable to be opened for writing.\n\
+            Is \"usg_directory\" key in config.ini wrong?")
+    control_data_corrected = re.sub(\
+        "Package: usg-benchmarks-*.$",\
+        "Package: usg-benchmarks-%s"%(altver),\
+        control_data,\
+        flags=re.MULTILINE)
+    control_file.write(control_data_corrected)
+    control_file.close()
+
+def gen_documentation(cac_directory, usg_directory):
+    # I'm opting to listen to the other module's outputs rather than rebuilding the module.
+    # This way the other module can still be used as it was originally designed.
+    
+    doc_gen_command = ["rules", "variables"]
+    doc_output = [""] * len(doc_gen_command)
+    for i in range(len(doc_gen_command)):
+        try:
+            exec_arg_1 = "%s/create_rule_and_variable_doc.py"%(tools_directory)
+            exec_arg_2 = doc_gen_command[i]
+            exec_arg_3 = "%s/%s/products/ubuntu2004/profiles"%(tools_directory, cac_directory)
+            exec_arg_4 = "%s/%s/benchmarks/Canonical_Ubuntu_20.04_Benchmarks-xccdf.xml"%(tools_directory, usg_directory)
+            doc_output[i] = subprocess.check_output([sys.executable, exec_arg_1, exec_arg_2, exec_arg_3, exec_arg_4]).decode()
+        except:
+            exit_error("\
+                Executing `%s %s %s %s` failed."%(sys.executable, exec_arg_1, exec_arg_2, exec_arg_3, exec_arg_4))
+
+    # In order of [rules, variables]
+    return (doc_output[0], doc_output[1])
+
+def gen_tailoring(cac_directory, usg_directory):
+
+    # This is an array of profile paths (below cac_directory) in the order of c1s, c1w, c2s, c2w, stig
+    tailoring_file_info = [
+            "products/ubuntu2004/profiles/cis_level1_server.profile",
+            "products/ubuntu2004/profiles/cis_level1_workstation.profile",
+            "products/ubuntu2004/profiles/cis_level2_server.profile",
+            "products/ubuntu2004/profiles/cis_level1_workstation.profile",
+            "products/ubuntu2004/profiles/stig.profile"]
+    
+    gen_tailoring_script = "%s/%s/utils/generate_tailoring_file.py"%(tools_directory, cac_directory)
+    benchmark_xml = "%s/%s/benchmarks/Canonical_Ubuntu_20.04_Benchmarks-xccdf.xml"%(tools_directory, usg_directory)
+    tailoring_data = [""] * len(tailoring_file_info)
+    
+    for i in range(len(tailoring_file_info)):
+        try:
+            exec_arg_1 = gen_tailoring_script
+            exec_arg_2 = "%s/%s/%s"%(tools_directory, cac_directory, tailoring_file_info[i])
+            exec_arg_3 = benchmark_xml
+            tailoring_data[i] = subprocess.check_output([sys.executable, exec_arg_1, exec_arg_2, exec_arg_3]).decode()
+        except:
+            exit_error("\
+                Executing `%s %s %s %s` failed."%(sys.executable, exec_arg_1, exec_arg_2, exec_arg_3))
+    
+    c1s_data = tailoring_data[0]
+    c1w_data = tailoring_data[1]
+    c2s_data = tailoring_data[2]
+    c2w_data = tailoring_data[3]
+    stig_data = tailoring_data[4]
+    return (c1s_data, c1w_data, c2s_data, c2w_data, stig_data)
+
+def mass_replacer(the_meat, meat_placeholder, package_version, alternative_version, current_timestamp, file_lines):
+    # This function significantly reduces code reuse and other potential ickyness.
+    # "the_meat" refers to the main data that needs to be put in the file,
+    #   ie the generated documentation or tailoring XML data.
+    # "meat_placeholder" is the template placeholder string for "the_meat"
+
+    # Generate the different time-related values that this function will use.
+    current_iso = current_timestamp.isoformat()
+    current_datestring = datetime.datetime.strftime(current_timestamp, "%d %B %Y")
+    current_year = current_timestamp.year
+    
+    corrected_lines = file_lines.replace("<<YEAR_PLACEHOLDER>>", str(current_year))\
+        .replace("<<DATE_PLACEHOLDER>>", str(current_datestring))\
+        .replace("<<ISODATETIME_PLACEHOLDER>>", str(current_iso))\
+        .replace("<<USG_BENCHMARKS_VERSION_PLACEHOLDER>>", str(package_version))\
+        .replace("<<USG_BENCHMARKS_ALTERNATIVE_PLACEHOLDER>>", str(alternative_version))\
+        .replace(meat_placeholder, str(the_meat))
+    
+    return corrected_lines
+
+def build_files(rules_doc, vars_doc, c1s_data, c1w_data, c2s_data, c2w_data, stig_data, package_version, alternative_version, current_timestamp, usg_directory):
+    # An array of [path, data, placeholder]
+    data_info = [
+        ["doc/man8/usg.md", "", "<<DOESNT_EXIST>>"],
+        ["doc/man7/usg-cis.md", "", "<<DOESNT_EXIST>>"],
+        ["doc/man7/usg-disa-stig.md", "", "<<DOESNT_EXIST>>"],
+        ["doc/man7/usg-rules.md", rules_doc, "<<USG_MAN_RULES_PLACEHOLDER>>"],
+        ["doc/man7/usg-variables.md", vars_doc, "<<USG_MAN_VARIABLE_PLACEHOLDER>>"],
+        ["tailoring/cis_level1_server-tailoring.xml", c1s_data, "<<LEVEL_1_SERVER_TAILORING_PLACEHOLDER>>"],
+        ["tailoring/cis_level1_workstation-tailoring.xml", c1w_data, "<<LEVEL_1_WORKSTATION_TAILORING_PLACEHOLDER>>"],
+        ["tailoring/cis_level2_server-tailoring.xml", c2s_data, "<<LEVEL_2_SERVER_TAILORING_PLACEHOLDER>>"],
+        ["tailoring/cis_level2_workstation-tailoring.xml", c2w_data, "<<LEVEL_2_WORKSTATION_TAILORING_PLACEHOLDER>>"],
+        ["tailoring/stig-tailoring.xml", stig_data, "<<STIG_TAILORING_PLACEHOLDER>>"]]
+
+    for specific_file_data in data_info:
+        try:
+            template_file = open("%s/%s/templates/%s"%(tools_directory, usg_directory, specific_file_data[0]), "r")
+        except:
+            exit_error("\
+                Template file at %s/%s/templates/%s cannot be opened."%(tools_directory, usg_directory, specific_file_data[0]))
+        try:
+            built_file = open("%s/%s/%s"%(tools_directory, usg_directory, specific_file_data[0]), "w")
+        except:
+             exit_error("\
+                File at %s/%s/%s cannot be opened for writing."%(tools_directory, usg_directory, specific_file_data[0]))
+        
+        template_data = template_file.read()
+        built_data = mass_replacer(specific_file_data[1], specific_file_data[2], package_version, alternative_version, current_timestamp, template_data)
+        built_file.write(built_data)
+        built_file.close()
+        template_file.close()
+
+def main(arg):
+    # Get the current timestamp
+    current_timestamp = datetime.datetime.utcnow().replace(microsecond=0)
+
+    # Read configuration variables from config.ini
+    package_version, alternative_version, target, usg_directory, cac_directory = load_config()
+    
+    # Run `pre_package_build.sh`
+    run_ppb(tools_directory, cac_directory, usg_directory)
+
+    # Update the alternative version number in debian/control
+    update_alternative_version(usg_directory, alternative_version)
+
+    # Generate the rules and variables documentation meat
+    rules_doc, vars_doc = gen_documentation(cac_directory, usg_directory)
+
+    # Generate the tailoring data
+    c1s_data, c1w_data, c2s_data, c2w_data, stig_data = gen_tailoring(cac_directory, usg_directory)
+
+    # Build the template files from all of the data that we've collected.
+    build_files(rules_doc,\
+                vars_doc,\
+                c1s_data,\
+                c1w_data,\
+                c2s_data,\
+                c2w_data,\
+                stig_data,\
+                package_version,\
+                alternative_version,\
+                current_timestamp,\
+                usg_directory)
+
+if __name__ == "__main__":
+    main(sys.argv)
+

--- a/tools/build_config.ini
+++ b/tools/build_config.ini
@@ -1,0 +1,16 @@
+[DEFAULT]
+# Package Version
+version=20.04.13~custom
+
+# Used for package alternatives, ie "usg-benchmarks-<this>"
+alternative_version=1
+
+# The CaC product build value: "ubuntu2004" is currently the only relevant target
+target=ubuntu2004
+
+# Root of USG directory relative to where this script is located
+usg_directory=..
+
+# Root of CaC directory relative to the root of the USG directory
+cac_directory=%(usg_directory)s/../ComplianceAsCode-content
+

--- a/tools/create_rule_and_variable_doc.py
+++ b/tools/create_rule_and_variable_doc.py
@@ -127,21 +127,21 @@ def markdown_output(item_dict, is_variable=False):
             extra_char=''
         print(f"### Description:\n\n```{ extra_char }{ it.description }\n```\n")
 
-if "__main__" == __name__:
+def main(args):
     profiles=['cis_level1_server.profile',
              'cis_level2_server.profile',
               'cis_level1_workstation.profile',
               'cis_level2_workstation.profile',
               'stig.profile']
-    usage=f'Usage: {sys.argv[0]} [ rules | variables ] <profile path> <xccdf file path>'
+    usage=f'Usage: {args[0]} [ rules | variables ] <profile path> <xccdf file path>'
 
-    if len(sys.argv) != 4:
+    if len(args) != 4:
         print(usage, file=sys.stderr)
         sys.exit(1)
 
-    command=sys.argv[1]
-    profile_path=sys.argv[2]
-    xccdf_path=sys.argv[3]
+    command=args[1]
+    profile_path=args[2]
+    xccdf_path=args[3]
 
     is_variable=False
     if command == 'variables':
@@ -155,3 +155,7 @@ if "__main__" == __name__:
     item_dict = create_item_dict_using_profiles(profile_paths, is_variable)
     fill_item_dict_using_xccdf(xccdf_path, item_dict, is_variable)
     markdown_output(item_dict, is_variable)
+
+
+if "__main__" == __name__:
+    main(sys.argv)


### PR DESCRIPTION
This commit introduces tooling changes and template files that automate the tailoring file and documentation file builds.

The non-template files (as well as the instructions to build them by hand) are still present, but we could/should one day remove the non-template files so there isn't accidental drift sometime after this is merged.