### PR TITLE
Release DataStream-format files with benchmark data

### DIFF
--- a/tools/pre_package_build.sh
+++ b/tools/pre_package_build.sh
@@ -36,6 +36,8 @@ cp "${cac_path}/ssg-ubuntu2004-cpe-dictionary.xml" "${usg_path}/Canonical_Ubuntu
 cp "${cac_path}/ssg-ubuntu2004-oval.xml" "${usg_path}"
 cp "${cac_path}/ssg-ubuntu2004-ocil.xml" "${usg_path}"
 cp "${cac_path}/ssg-ubuntu2004-cpe-oval.xml" "${usg_path}"
+cp "${cac_path}/ssg-ubuntu2004-ds.xml" "${usg_path}"
+cp "${cac_path}/ssg-ubuntu2004-ds-1.2.xml" "${usg_path}"
 
 # Copy the license file
 cp $(dirname "${cac_path}")/LICENSE "${usg_path}"/ComplianceAsCode-LICENSE


### PR DESCRIPTION
This commit updates tools/pre_package_build.sh to include the two CaC-generated DataStream-format files with the other benchmark data that we provide.
This format was recently requested by a customer.

For reference, these DS files may also be generated by hand post-CaC with `oscap ds sds-compose some-xccdf-1.2.xml target-datastream.xml` -- this is not provided in any internal documentation yet since we've opted to provide the DS files instead.