### PR TITLE
Update ubuntu-security-guides-enhanced name in d/control

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,4 +1,4 @@
-Source: ubuntu-security-guides
+Source: ubuntu-security-guides-enhanced
 Section: misc
 Priority: optional
 Maintainer: Ubuntu Security <security@ubuntu.com>


### PR DESCRIPTION
The 20.04.13 released package has the package name "ubuntu-security-guides-enhanced"
This code, though, used the name "ubuntu-security-guides" in the same spot in d/control.
This commit corrects this repository.
