### PR TITLE
Add --oval-results flag to dump OVAL results

### DIFF
--- a/sbin/usg
+++ b/sbin/usg
@@ -66,6 +66,7 @@ function usage_common_options()
 {
     echo "	--html-file <path to file>          Overrides the HTML output file
 	--results-file <path to file>       Overrides the results file
+	--oval-results                      Dumps the OVAL results files into the CWD
 "
 }
 
@@ -172,6 +173,7 @@ alternatives entry 'usg_current_benchmarks' is properly configured.
 remediate_flag=""
 output_flag=""
 tailoring_flag=""
+oval_results_flag=""
 
 function usage
 {
@@ -277,7 +279,7 @@ command="$1"
 case "${command}" in
     $AUDIT_CMD|$FIX_CMD)
         shift
-        all_params=$(getopt -n ${prog_name} -oh --long tailoring-file:,html-file:,results-file:,help -- "$@")
+        all_params=$(getopt -n ${prog_name} -oh --long tailoring-file:,html-file:,results-file:,oval-results,help -- "$@")
         ;;
     $GENFIX_CMD)
         shift
@@ -309,10 +311,12 @@ while true ; do
             output_flag="$1 $2"; shift 2 ;;
         --tailoring-file)
             tailoring_file=$2; shift 2 ;;
-	--html-file)
-	    HTML_FILE=$2; shift 2 ;;
-	--results-file)
-	    RESULTS_FILE=$2; shift 2;;
+        --html-file)
+	        HTML_FILE=$2; shift 2 ;;
+        --results-file)
+            RESULTS_FILE=$2; shift 2;;
+        --oval-results)
+            oval_results_flag="--oval-results"; shift;;
         -h|--help)
             usage "${command}"
             exit 0
@@ -372,7 +376,7 @@ if [ "${command}" == $FIX_CMD ]; then
 fi
 case "${command}" in
     $AUDIT_CMD|$FIX_CMD)
-        command="oscap xccdf eval --profile ${profile} --cpe $FOCAL_CPE_DICTIONARY_FILE --results $RESULTS_FILE ${tailoring_flag} ${remediate_flag} $FOCAL_XCCDF_FILE"
+        command="oscap xccdf eval --profile ${profile} --cpe $FOCAL_CPE_DICTIONARY_FILE --results $RESULTS_FILE ${tailoring_flag} ${oval_results_flag} ${remediate_flag} $FOCAL_XCCDF_FILE"
 
         # remove old results file
 	mkdir -p $RESULTS_DIR


### PR DESCRIPTION
Some background for this PR:
Based off of [LP#1966068](https://bugs.launchpad.net/ubuntu-security-certifications/+bug/1966068), I was taking a look into the `oscap xccdf eval ... --oval-results` flag. This flag is a little strange: there's no way to specify an output filename or directory, it only uses the CWD.

In oscap's manpage, it says that a ...
> File with name 'original-oval-definitions-filename.result.xml' will be generated for each referenced OVAL file in current working directory

... so it seems like the resulting file name should be predictable. However, when I use this flag with oscap using our current content, it generates two files *with different content* :
- ssg-ubuntu2004-cpe-oval.xml
- %2Fusr%2Fshare%2Fubuntu-scap-security-guides%2Fcurrent%2Fbenchmarks%2Fssg-ubuntu2004-cpe-oval.xml.result.xml

When I search through our content's CPE Dictionary file, I only see the first of those mentioned; I see no differences that should create a second file.


Although it seems a little out-of character for the usg tool, I've created this PR's commit that will let oscap dump the resulting files in the CWD. This might be a better path long-term rather than predicting and renaming the result files, like [this commit](https://github.com/arossbell/ubuntu-security-guide/commit/beaea35e2d9d24473f2f940164ff6f90cd5a5954), as the content changes.