### PR TITLE
Version 22.04.5

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -8,9 +8,9 @@ ubuntu-security-guides-enhanced (22.04.5) jammy-security; urgency=medium
     var_nftables_base_chain_policies (LP: #2041270)
     - Fix pam file list in pam_faillock
   * USG Tool: Fix to correctly replace alternative version in control file
+  * Fix postinstall script: Set usg_benchmark to correct alternative version
 
-
- -- Miha Purg <miha.purg@canonical.com>  Wed, 17 Jan 2024 11:24:56 +0100
+ -- Miha Purg <miha.purg@canonical.com>  Mon, 17 Jan 2024 14:30:00 +0100
 
 ubuntu-security-guides-enhanced (22.04.3) jammy; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,17 @@
+ubuntu-security-guides-enhanced (22.04.5) jammy-security; urgency=medium
+
+  * CaC content: Bug fixes
+    - Improve regex for pam_faillock
+    - Fix remediation for set_nftables_loopback that caused DNS resolution
+    to fail (LP: #2039445)
+    - Add missing variable and fix default value of
+    var_nftables_base_chain_policies (LP: #2041270)
+    - Fix pam file list in pam_faillock
+  * USG Tool: Fix to correctly replace alternative version in control file
+
+
+ -- Miha Purg <miha.purg@canonical.com>  Wed, 17 Jan 2024 11:24:56 +0100
+
 ubuntu-security-guides-enhanced (22.04.3) jammy; urgency=medium
 
   * CaC content: Various CIS bug fixes

--- a/debian/usg-benchmarks.postinst
+++ b/debian/usg-benchmarks.postinst
@@ -7,3 +7,5 @@ update-alternatives --install "${path}/current" usg_benchmarks "${path}/${versio
     --slave /usr/share/man/man7/usg-cis.gz usg-cis /usr/share/man/man7/usg-cis-${version}.7.gz \
     --slave /usr/share/man/man7/usg-rules.gz usg-rules /usr/share/man/man7/usg-rules-${version}.7.gz \
     --slave /usr/share/man/man7/usg-variables.gz usg-variables /usr/share/man/man7/usg-variables-${version}.7.gz
+
+update-alternatives --set usg_benchmarks "${path}/${version}"

--- a/tools/build_config.ini
+++ b/tools/build_config.ini
@@ -1,6 +1,6 @@
 [DEFAULT]
 # Package Version
-version=22.04.3
+version=22.04.5
 
 # Used for package alternatives, ie "usg-benchmarks-<this>"
 alternative_version=1


### PR DESCRIPTION
CaC content: Bug fixes
    - Improve regex for pam_faillock
    - Fix remediation for set_nftables_loopback that caused DNS resolution
    to fail (LP: #2039445)
    - Add missing variable and fix default value of
    var_nftables_base_chain_policies (LP: #2041270)
    - Fix pam file list in pam_faillock

USG Tool: Fix to correctly replace alternative version in control file