### PR TITLE
Version 22.04.6

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,22 @@
+ubuntu-security-guides-enhanced (22.04.6) jammy; urgency=medium
+
+  * Minor fixes and improvements for CIS and DISA STIG:
+    - Improve remediation for accounts_passwords_pam_faillock_* rules
+    - Modify rules for disabling kernel modules to use /bin/false
+    - Fix remediation text for sshd_config MACs (LP: #2051884)
+    - Fix auditd rules for ssh-keysign and networkconfig (LP: #2052900)
+    - Improve sshd rules to check configs in /etc/ssh/sshd_config.d/*
+    - Fix remediation text for auditd_max_log_file_action (LP: #2052940)
+    - Fix sudoers configuration parsing (LP: #2053238)
+    - Improve umask rule to check configs in /etc/profile.d/* (LP: #2053239)
+    - Disable intrusive remediation for rule umask_interactive_users
+    - Fix logic for rules checking local interactive accounts
+    - Improve grub2 rules to check configs in /etc/default/grub.d/*
+  * Fix postinstall and prerm scripts to not reset user preferences
+    in update-alternatives
+
+ -- Miha Purg <miha.purg@canonical.com>  Wed, 28 Feb 2024 15:00:51 +0100
+
 ubuntu-security-guides-enhanced (22.04.5) jammy-security; urgency=medium
 
   * CaC content: Bug fixes

--- a/debian/usg-benchmarks.postinst
+++ b/debian/usg-benchmarks.postinst
@@ -1,11 +1,13 @@
 #!/bin/sh
+set -e
 
 version=$(echo "${DPKG_MAINTSCRIPT_PACKAGE}" | grep -Po '(?<=usg-benchmarks-).*')
 path=$(dpkg -L ${DPKG_MAINTSCRIPT_PACKAGE} | grep -Po '(/.*)+'"(?=/${version}/benchmarks)" | uniq)
+priority=$(( 100 + ${version} ))
 
-update-alternatives --install "${path}/current" usg_benchmarks "${path}/${version}" 50 \
+update-alternatives --install "${path}/current" usg_benchmarks "${path}/${version}" "${priority}" \
     --slave /usr/share/man/man7/usg-cis.gz usg-cis /usr/share/man/man7/usg-cis-${version}.7.gz \
     --slave /usr/share/man/man7/usg-rules.gz usg-rules /usr/share/man/man7/usg-rules-${version}.7.gz \
     --slave /usr/share/man/man7/usg-variables.gz usg-variables /usr/share/man/man7/usg-variables-${version}.7.gz
 
-update-alternatives --set usg_benchmarks "${path}/${version}"
+exit 0

--- a/debian/usg-benchmarks.prerm
+++ b/debian/usg-benchmarks.prerm
@@ -1,6 +1,19 @@
 #!/bin/sh
+set -e
 
 version=$(echo "${DPKG_MAINTSCRIPT_PACKAGE}" | grep -Po '(?<=usg-benchmarks-).*')
 path=$(dpkg -L ${DPKG_MAINTSCRIPT_PACKAGE} | grep -Po '(/.*)+'"(?=/${version}/benchmarks)" | uniq)
 
-update-alternatives --remove usg_benchmarks ${path}/${version}
+case "${1}" in
+    remove|deconfigure|failed-upgrade)
+        update-alternatives --remove usg_benchmarks ${path}/${version}
+    ;;
+    upgrade)
+    ;;
+    *)
+        echo "prerm called with unknown argument \`$1'" >&2
+        exit 1
+    ;;
+esac
+
+exit 0

--- a/tools/build_config.ini
+++ b/tools/build_config.ini
@@ -1,6 +1,6 @@
 [DEFAULT]
 # Package Version
-version=22.04.5
+version=22.04.6
 
 # Used for package alternatives, ie "usg-benchmarks-<this>"
 alternative_version=1


### PR DESCRIPTION
#### Release info

- Minor fixes and improvements
- Backwards compatible with old tailoring files (provides same `usg-benchmarks-1` package as previous release)

#### Changelog

  * Minor fixes and improvements for CIS and DISA STIG:
    - Improve remediation for accounts_passwords_pam_faillock_* rules
    - Modify rules for disabling kernel modules to use /bin/false
    - Fix remediation text for sshd_config MACs (LP: #2051884)
    - Fix auditd rules for ssh-keysign and networkconfig (LP: #2052900)
    - Improve sshd rules to check configs in /etc/ssh/sshd_config.d/*
    - Fix remediation text for auditd_max_log_file_action (LP: #2052940)
    - Fix sudoers configuration parsing (LP: #2053238)
    - Improve umask rule to check configs in /etc/profile.d/* (LP: #2053239)
    - Disable intrusive remediation for rule umask_interactive_users
    - Fix logic for rules checking local interactive accounts
    - Improve grub2 rules to check configs in /etc/default/grub.d/*
  * Fix postinstall and prerm scripts to not reset user preferences in update-alternatives