### PR TITLE
Version 20.04.19

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+ubuntu-security-guides-enhanced (20.04.19) focal; urgency=medium
+
+  * Minor fixes and improvements for CIS and DISA STIG:
+    - Update DISA STIG to V1R11
+    - Improve remediation for accounts_passwords_pam_faillock_* rules
+    - Fix remediation for pam_faildelay (LP: #2051976)
+    - Fix sudoers configuration parsing (LP: #2053238)
+    - Improve umask rule to check configs in /etc/profile.d/* (LP: #2053239)
+  * Fix postinstall and prerm scripts to not reset user preferences
+    in update-alternatives
+
+ -- Miha Purg <miha.purg@canonical.com>  Wed, 28 Feb 2024 15:43:11 +0100
+
 ubuntu-security-guides-enhanced (20.04.18) focal; urgency=medium
 
   * CaC content:

--- a/debian/control
+++ b/debian/control
@@ -19,7 +19,7 @@ Architecture: all
 Depends: usg, ${misc:Depends}
 Description: SCAP content for CIS and DISA-STIG Ubuntu Benchmarks
  This package contains SCAP content to support the automation of
- compliance evaluation for CIS v1.0.0 and DISA-STIG V1R10 Benchmarks.
+ compliance evaluation for CIS v1.0.0 and DISA-STIG V1R11 Benchmarks.
  This includes XCCDF, OVAL, CPE and tailoring files.
  .
  SCAP (Security Content Automation Protocol) is a set of standards to

--- a/debian/usg-benchmarks.postinst
+++ b/debian/usg-benchmarks.postinst
@@ -1,12 +1,14 @@
 #!/bin/sh
+set -e
 
 version=$(echo "${DPKG_MAINTSCRIPT_PACKAGE}" | grep -Po '(?<=usg-benchmarks-).*')
 path=$(dpkg -L ${DPKG_MAINTSCRIPT_PACKAGE} | grep -Po '(/.*)+'"(?=/${version}/benchmarks)" | uniq)
+priority=$(( 100 + ${version} ))
 
-update-alternatives --install "${path}/current" usg_benchmarks "${path}/${version}" 50 \
+update-alternatives --install "${path}/current" usg_benchmarks "${path}/${version}" "${priority}" \
     --slave /usr/share/man/man7/usg-cis.gz usg-cis /usr/share/man/man7/usg-cis-${version}.7.gz \
     --slave /usr/share/man/man7/usg-disa-stig.gz usg-stig /usr/share/man/man7/usg-disa-stig-${version}.7.gz \
     --slave /usr/share/man/man7/usg-rules.gz usg-rules /usr/share/man/man7/usg-rules-${version}.7.gz \
     --slave /usr/share/man/man7/usg-variables.gz usg-variables /usr/share/man/man7/usg-variables-${version}.7.gz
 
-update-alternatives --set usg_benchmarks "${path}/${version}"
+exit 0

--- a/debian/usg-benchmarks.prerm
+++ b/debian/usg-benchmarks.prerm
@@ -1,6 +1,19 @@
 #!/bin/sh
+set -e
 
 version=$(echo "${DPKG_MAINTSCRIPT_PACKAGE}" | grep -Po '(?<=usg-benchmarks-).*')
 path=$(dpkg -L ${DPKG_MAINTSCRIPT_PACKAGE} | grep -Po '(/.*)+'"(?=/${version}/benchmarks)" | uniq)
 
-update-alternatives --remove usg_benchmarks ${path}/${version}
+case "${1}" in
+    remove|deconfigure|failed-upgrade)
+        update-alternatives --remove usg_benchmarks ${path}/${version}
+    ;;
+    upgrade)
+    ;;
+    *)
+        echo "prerm called with unknown argument \`$1'" >&2
+        exit 1
+    ;;
+esac
+
+exit 0

--- a/templates/doc/man7/usg-disa-stig.md
+++ b/templates/doc/man7/usg-disa-stig.md
@@ -93,7 +93,7 @@ A manual fix is required if the software is not available.
 ```
 
 # INTERNET RESOURCES
-Ubuntu 20.04 STIG Benchmark: https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/U\_CAN\_Ubuntu\_20-04\_LTS\_V1R1\_STIG.zip
+Ubuntu 20.04 STIG Benchmark: https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/U\_CAN\_Ubuntu\_20-04\_LTS\_V1R11\_STIG.zip
 
 # SEE ALSO
 **usg**(8), **usg-rules**(7), **usg-variables**(7)

--- a/templates/doc/man8/usg.md
+++ b/templates/doc/man8/usg.md
@@ -116,7 +116,7 @@ The *usg* tool depends on one or more *usg-benchmarks-\<VERSION\>* packages to b
 ## Benchmark package version
 The \<VERSION\> suffix is used to provide information regarding changes to the benchmarks bundled into the Benchmarks package. So, the package starts with \<VERSION\> is initially
 set to 1 and this value is increased each time a bundled benchmark receives an upgrade. For instance, the package version 1 contains CIS benchmark version 1.0.0 and DISA-STIG version
-V1R1. Canonical may decide to update CIS benchmark to version 2.0.1, but keep DISA-STIG version V1R1, which will lead to an a new Benchmarks package version 2.
+V1R10. Canonical may decide to update CIS benchmark to version 2.0.1, but keep DISA-STIG version V1R10, which will lead to an a new Benchmarks package version 2.
 Note that the Benchmarks package version is not tied to the bundled benchmarks versions!
 
 So, if both *usg-benchmarks-1* and *usg-benchmarks-2* packages are installed, the system will output the following lines when listing the packages:
@@ -230,7 +230,7 @@ OpenScap: https://www.open-scap.org/
 
 Ubuntu 20.04 CIS Benchmark: https://workbench.cisecurity.org/benchmarks/5288
 
-Ubuntu 20.04 STIG Benchmark: https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/U\_CAN\_Ubuntu\_20-04\_LTS\_V1R1\_STIG.zip
+Ubuntu 20.04 STIG Benchmark: https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/U\_CAN\_Ubuntu\_20-04\_LTS\_V1R11\_STIG.zip
 
 # SEE ALSO
 **usg-rules**(7), **usg-variables**(7), **usg-cis**(7), **usg-disa-stig**(7), **oscap**(8), **update-alternatives**(1)

--- a/templates/tailoring/stig-tailoring.xml
+++ b/templates/tailoring/stig-tailoring.xml
@@ -4,6 +4,6 @@
   <cdf-11-tailoring:version time="PLACEHOLDER">1</cdf-11-tailoring:version>
   <xccdf:Profile id="stig_customized" extends="stig">
     <xccdf:title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">DISA-STIG Benchmark [CUSTOMIZED]</xccdf:title>
-    <xccdf:description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the DISA-STIG v.1, rel.1, released 04-06-2021.</xccdf:description>
+    <xccdf:description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the DISA-STIG V1R11, released 01-24-2024.</xccdf:description>
   </xccdf:Profile>
 </cdf-11-tailoring:Tailoring>

--- a/tools/build_config.ini
+++ b/tools/build_config.ini
@@ -1,6 +1,6 @@
 [DEFAULT]
 # Package Version
-version=20.04.18
+version=20.04.19
 
 # Used for package alternatives, ie "usg-benchmarks-<this>"
 alternative_version=2


### PR DESCRIPTION
#### Release info

- Minor fixes and improvements including update of benchmark DISA STIG to release V1R11
- Backwards compatible with old tailoring files (provides same `usg-benchmarks-2` package as previous release)

#### Changelog
  * Minor fixes and improvements for CIS and DISA STIG:
    - Update DISA STIG to V1R11
    - Improve remediation for accounts_passwords_pam_faillock_* rules
    - Fix remediation for pam_faildelay (LP: #2051976)
    - Fix sudoers configuration parsing (LP: #2053238)
    - Improve umask rule to check configs in /etc/profile.d/* (LP: #2053239)
  * Fix postinstall and prerm scripts to not reset user preferences in update-alternatives