### PR TITLE
Fix installation and removal of alternative versions

### DIFF
--- a/debian/usg-benchmarks.postinst
+++ b/debian/usg-benchmarks.postinst
@@ -1,11 +1,13 @@
 #!/bin/sh
+set -e
 
 version=$(echo "${DPKG_MAINTSCRIPT_PACKAGE}" | grep -Po '(?<=usg-benchmarks-).*')
 path=$(dpkg -L ${DPKG_MAINTSCRIPT_PACKAGE} | grep -Po '(/.*)+'"(?=/${version}/benchmarks)" | uniq)
+priority=$(( 100 + ${version} ))
 
-update-alternatives --install "${path}/current" usg_benchmarks "${path}/${version}" 50 \
+update-alternatives --install "${path}/current" usg_benchmarks "${path}/${version}" "${priority}" \
     --slave /usr/share/man/man7/usg-cis.gz usg-cis /usr/share/man/man7/usg-cis-${version}.7.gz \
     --slave /usr/share/man/man7/usg-rules.gz usg-rules /usr/share/man/man7/usg-rules-${version}.7.gz \
     --slave /usr/share/man/man7/usg-variables.gz usg-variables /usr/share/man/man7/usg-variables-${version}.7.gz
 
-update-alternatives --set usg_benchmarks "${path}/${version}"
+exit 0

--- a/debian/usg-benchmarks.prerm
+++ b/debian/usg-benchmarks.prerm
@@ -1,6 +1,19 @@
 #!/bin/sh
+set -e
 
 version=$(echo "${DPKG_MAINTSCRIPT_PACKAGE}" | grep -Po '(?<=usg-benchmarks-).*')
 path=$(dpkg -L ${DPKG_MAINTSCRIPT_PACKAGE} | grep -Po '(/.*)+'"(?=/${version}/benchmarks)" | uniq)
 
-update-alternatives --remove usg_benchmarks ${path}/${version}
+case "${1}" in
+    remove|deconfigure|failed-upgrade)
+        update-alternatives --remove usg_benchmarks ${path}/${version}
+    ;;
+    upgrade)
+    ;;
+    *)
+        echo "prerm called with unknown argument \`$1'" >&2
+        exit 1
+    ;;
+esac
+
+exit 0


### PR DESCRIPTION
Cherry picked the fix that's been included in 22.04.6 and 20.04.19 also to master.

#### Description

Maintainer scripts in usg-benchmarks-N package redefined the alternative version on upgrade, overriding user's manual selection of alternative version.

Changes introduced in this fix:
- remove manual setting of alternative version in postinst script
- increase priority of alternative package in postinst script to switch to the latest version when in auto mode
- prevent removal of alternative version during an upgrade in prerm script to avoid resetting user preferences
- add -e to postinst and prerm scripts
