### PR TITLE
Release 22.04.7

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,24 @@
+ubuntu-security-guides-enhanced (22.04.7) jammy; urgency=medium
+
+  * New benchmark STIG V1R1 for Ubuntu 22.04 LTS
+  * Minor fixes and improvements for CIS:
+    - Fix non-idempotent bash remediation for sysctl template (LP: #2056150)
+    - Add missing !package_cups_removed to cis_level1 profile (LP: #2057945)
+    - Fix handling of grub.d configs in grub2_bootloader_argument
+    - Fix check for accounts_user_dot_no_world_writable_programs
+    - Fix remediations on config files without trailing newlines (LP: #2061072)
+    - Modify dconf package name to fix false positives in dconf rules
+    - Enable dconf profiles in bash remediation of dconf rules
+    - Fix SCE check for iptables_open_ports (LP: #2061213)
+    - Fix SCE checks for iptables_loopback_traffic (LP: #2061215)
+    - Add missing rule package_pam_pwquality_installed (LP: #2065113)
+    - Disable all remediation languages except bash in compiled benchmarks
+    - Add a warning to sshd_limit_user_access
+    - Fix check for non-existing audispd in aide_check_audit_tools
+  * Update README to add how to report issues
+
+ -- Miha Purg <miha.purg@canonical.com>  Fri, 14 Jun 2024 12:06:30 +0200
+
 ubuntu-security-guides-enhanced (22.04.6) jammy; urgency=medium
 
   * Minor fixes and improvements for CIS and DISA STIG:

--- a/debian/rules
+++ b/debian/rules
@@ -30,9 +30,11 @@ override_dh_auto_build-indep:
 	pandoc doc/man7/usg-variables.md -s -t man -o doc/man7/usg-variables.7
 	pandoc doc/man7/usg-rules.md -s -t man -o doc/man7/usg-rules.7
 	pandoc doc/man7/usg-cis.md -s -t man -o doc/man7/usg-cis.7
+	pandoc doc/man7/usg-disa-stig.md -s -t man -o doc/man7/usg-disa-stig.7
 
 override_dh_install:
 	ln -sf usg-cis.7 doc/man7/usg-cis-$(BENCHMARK_VERSION).7
+	ln -sf usg-disa-stig.7 doc/man7/usg-disa-stig-$(BENCHMARK_VERSION).7
 	ln -sf usg-rules.7 doc/man7/usg-rules-$(BENCHMARK_VERSION).7
 	ln -sf usg-variables.7 doc/man7/usg-variables-$(BENCHMARK_VERSION).7
 	# Update links based on package name from debian/control

--- a/debian/usg-benchmarks.manpages
+++ b/debian/usg-benchmarks.manpages
@@ -1,3 +1,4 @@
 doc/man7/usg-cis-${env:BENCHMARK_VERSION}.7
+doc/man7/usg-disa-stig-${env:BENCHMARK_VERSION}.7
 doc/man7/usg-rules-${env:BENCHMARK_VERSION}.7
 doc/man7/usg-variables-${env:BENCHMARK_VERSION}.7

--- a/debian/usg-benchmarks.postinst
+++ b/debian/usg-benchmarks.postinst
@@ -7,6 +7,7 @@ priority=$(( 100 + ${version} ))
 
 update-alternatives --install "${path}/current" usg_benchmarks "${path}/${version}" "${priority}" \
     --slave /usr/share/man/man7/usg-cis.gz usg-cis /usr/share/man/man7/usg-cis-${version}.7.gz \
+    --slave /usr/share/man/man7/usg-disa-stig.gz usg-disa-stig /usr/share/man/man7/usg-disa-stig-${version}.7.gz \
     --slave /usr/share/man/man7/usg-rules.gz usg-rules /usr/share/man/man7/usg-rules-${version}.7.gz \
     --slave /usr/share/man/man7/usg-variables.gz usg-variables /usr/share/man/man7/usg-variables-${version}.7.gz
 

--- a/sbin/usg
+++ b/sbin/usg
@@ -24,7 +24,11 @@
 ###########################################################
 
 # PROFILES point to the tailoring files which mirrors the profiles
-declare -A PROFILES=( ["cis_level1_server"]="cis_level1_server-tailoring.xml" ["cis_level2_server"]="cis_level2_server-tailoring.xml" ["cis_level1_workstation"]="cis_level1_workstation-tailoring.xml" ["cis_level2_workstation"]="cis_level2_workstation-tailoring.xml" )
+declare -A PROFILES=( ["cis_level1_server"]="cis_level1_server-tailoring.xml" \
+                      ["cis_level2_server"]="cis_level2_server-tailoring.xml" \
+                      ["cis_level1_workstation"]="cis_level1_workstation-tailoring.xml" \
+                      ["cis_level2_workstation"]="cis_level2_workstation-tailoring.xml" \
+                      ["disa_stig"]="stig-tailoring.xml" )
 
 BASE_DIR="/usr/share/ubuntu-scap-security-guides/current"
 TAILORING_DIR="$BASE_DIR/tailoring"
@@ -207,12 +211,6 @@ function validate_profile
 
     if [ -z "$1" ];then
         echoerr "Error: a profile or a tailoring file must be provided."
-        usage "${command}"
-        exit 1
-    fi
-
-    if [ "$profile" == "disa_stig" ]; then
-        echoerr "disa_stig profile not yet available for Ubuntu 22.04!"
         usage "${command}"
         exit 1
     fi

--- a/templates/doc/man7/usg-disa-stig.md
+++ b/templates/doc/man7/usg-disa-stig.md
@@ -1,5 +1,6 @@
 % USG-DISA-STIG(7) usg-benchmarks-<<USG_BENCHMARKS_ALTERNATIVE_PLACEHOLDER>> <<USG_BENCHMARKS_VERSION_PLACEHOLDER>>
 % Eduardo Barretto <eduardo.barretto@canonical.com>
+% Miha Purg <miha.purg@canonical.com>
 % <<DATE_PLACEHOLDER>>
 
 # NAME
@@ -29,11 +30,7 @@ The setting for remote_server in /etc/audisp/audisp-remote.conf
 ```
 
 ## Rules limitations
-A few rules provided by the stig profile require manual fix. 
-
-In addition, currently the rule *permission\_local\_var\_log* is unable to prevent new log files being created with permissions that violate the DISA-STIG requirements.
-
-Follow a list of the rules below which matches one of the cases above:
+A few rules provided by the stig profile require manual inspection and fix.
 
 ### Rule id: auditd\_offload\_logs
 #### Title: Offload audit Logs to External Media
@@ -48,28 +45,15 @@ Check if there is a script in the "/etc/cron.weekly" directory that offloads aud
 audit-offload 
 ```
 
-### Rule id: chronyd\_or\_ntpd\_set\_maxpoll
-#### Title: Configure Time Service Maxpoll Interval
+### Rule id: auditd\_audispd\_configure\_sufficiently\_large\_partition
+#### Title: Configure a Sufficiently Large Partition for Audit Logs
 #### Description:
 
 ```
-The maxpoll should be configured in /etc/ntp.conf or
-/etc/chrony/chrony.conf to continuously poll time servers. To configure
-maxpoll in /etc/ntp.conf or /etc/chrony/chrony.conf
-add the following after each `server` entry:
-maxpoll
-
-NOTE: The DISA-STIG rule currently does not support `pool` or `peer` entries.
-```
-
-### Rule id: permission\_local\_var\_log
-#### Title:
-#### Description:
-
-```
-This rule will enforce a permission of 0640 for files inside the /var/log directory when its audit process runs.
-However, any change made after the audit process ends potentially can put the system in an uncompliant-state
-with regard to that rules.
+The rule requires a sufficiently large partition for storing at least one week's
+worth of audit logs. As this is highly dependent on the end-user's enviroment,
+the check and remediation for the rule are not implemented and must be performed
+manually.
 ```
 
 ### Rule id: is\_fips\_mode\_enabled
@@ -83,8 +67,8 @@ For more informations on how to run the system in FIPS-140-2 mode, please see
 https://ubuntu.com/security/certifications/docs/fips-enablement
 ```
 
-### Rule    package\_mfetp\_installed
-#### Title: Install Endpoint Security for Linux Threat Prevention
+### Rule id: install\_endpoint\_security\_software
+#### Title: Install an Endpoint Security Software
 #### Description:
 
 ```
@@ -92,8 +76,133 @@ This rule requires a third-party software to be installed.
 A manual fix is required if the software is not available.
 ```
 
+### Rule id: smartcard\_pam\_enabled
+#### Title: Enable Smart Card Logins in PAM
+#### Description:
+
+```
+This rule requires that the pam_pkcs11.so module is added to the PAM
+authentication stack. Due to potential complexity of PAM configurations,
+and risk of lock-out, the automated remediation has been disabled.
+
+Add the following to the top of the stack in /etc/pam.d/common-auth,
+replacing N with the correct number of jumps:
+
+auth     [success=N default=ignore]     pam_pkcs11.so
+
+e.g.
+auth     [success=3 default=ignore]     pam_pkcs11.so
+auth     [success=2 default=ignore]     pam_unix.so nullok
+auth     [success=1 default=ignore]     pam_sss.so use_first_pass
+```
+
+### Rule id: grub2\_password
+#### Title: Set Boot Loader Password in grub2
+#### Description:
+
+```
+To prevent hard-coded passwords, automated remediation of this rule
+is not available. Remediation must be automated as a component of machine
+provisioning, or performed manually.
+
+1) Generate the password:
+$ grub-mkpasswd-pbkdf2 
+
+2) Add the following lines to /etc/grub.d/40_custom:
+set superusers="root"
+password_pbkdf2 root GENERATED_PASSWORD
+
+3) Update grub
+$ sudo update-grub
+```
+
+### Rule id: check\_ufw\_active
+#### Title: Verify ufw Active
+#### Description:
+
+```
+The UFW firewall should be enabled and active.
+The rule does not enable the firewall automatically to avoid lock-out.
+
+To remediate, run:
+$ ufw enable
+```
+
+### Rule id: ufw\_rate\_limit
+#### Title: ufw Must rate-limit network interfaces
+#### Description:
+
+```
+This rule requires that UFW is enabled and configured to rate-limit all services.
+The firewall is not configured and enabled automatically to avoid lock-out.
+
+To remediate, determine all listening services and set the rate-limit:
+$ ss -l46ut
+$ ufw limit SERVICE_NAME
+```
+
+### Rule id: encrypt\_partitions
+#### Title: Encrypt Partitions
+#### Description:
+
+```
+The system should be configured to prevent unauthorized disclosure or
+modification of all information requiring at-rest protection by using disk encryption. 
+
+The rule presently does not perform this check and it must be done manually.
+```
+
+### Rule id: account\_temp\_expire_date
+#### Title: Assign Expiration Date to Temporary Accounts
+#### Description:
+
+```
+This rule is not automated as temporary accounts cannot be differentiated
+from regular accounts.
+```
+
+### Rule id: temp\_passwords\_immediate\_change
+#### Title: Policy Requires Immediate Change of Temporary Passwords
+#### Description:
+
+```
+This rule is not automated as temporary accounts cannot be differentiated
+from regular accounts.
+```
+
+### Rule id: sudo\_group\_restricted
+#### Title: Ensure sudo group has only necessary members
+#### Description:
+
+```
+This rule is not automated because sudo users are unique to the end-user's environment.
+
+Verify only authorized users are in the sudo group:
+$ grep sudo /etc/group  
+```
+
+### Rule id: ufw\_only\_required_services
+#### Title: Only Allow Authorized Network Services in ufw
+#### Description:
+
+```
+This rule is not automated because the list of authorized network services
+is unique to the end-user's environment.
+```
+
+### Rule id: only\_allow\_dod\_certs
+#### Title: Only Allow DoD PKI-established CAs
+#### Description:
+
+```
+The rule is not automated. It requires that all certifications found in
+/etc/ssl/certs are approved by the AO.
+```
+
+
+
 # INTERNET RESOURCES
-Ubuntu 20.04 STIG Benchmark: https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/U\_CAN\_Ubuntu\_20-04\_LTS\_V1R1\_STIG.zip
+Ubuntu 22.04 STIG Benchmark: https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/U\_CAN\_Ubuntu\_22-04\_LTS\_V1R1\_STIG.zip
 
 # SEE ALSO
 **usg**(8), **usg-rules**(7), **usg-variables**(7)

--- a/templates/tailoring/stig-tailoring.xml
+++ b/templates/tailoring/stig-tailoring.xml
@@ -5,6 +5,6 @@
   <Profile id="xccdf_org.ssgproject.content_profile_stig_customized"
       extends="xccdf_org.ssgproject.content_profile_stig">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">DISA-STIG Benchmark [CUSTOMIZED]</title>
-    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the DISA-STIG v.1, rel.1, released 04-06-2021.</description>
+    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the DISA-STIG v.1, rel.1, released 2024-04-10.</description>
   </Profile>
 </Tailoring>

--- a/tools/build.py
+++ b/tools/build.py
@@ -177,13 +177,15 @@ def gen_tailoring(cac_directory, usg_directory, target, benchmark_version):
         "cis_level1_server.profile",
         "cis_level1_workstation.profile",
         "cis_level2_server.profile",
-        "cis_level2_workstation.profile"]
+        "cis_level2_workstation.profile",
+        "stig.profile"]
 
     tailoring_template = [
         "templates/tailoring/cis_level1_server-tailoring.xml",
         "templates/tailoring/cis_level1_workstation-tailoring.xml",
         "templates/tailoring/cis_level2_server-tailoring.xml",
-        "templates/tailoring/cis_level2_workstation-tailoring.xml"]
+        "templates/tailoring/cis_level2_workstation-tailoring.xml",
+        "templates/tailoring/stig-tailoring.xml"]
 
     gen_tailoring_script = "%s/generate_tailoring_file.py" % (tools_directory)
     benchmark_xml = \
@@ -243,6 +245,7 @@ def build_files(rules_doc, vars_doc,
     data_info = [
         ["doc/man8/usg.md", "", "<<DOESNT_EXIST>>"],
         ["doc/man7/usg-cis.md", "", "<<DOESNT_EXIST>>"],
+        ["doc/man7/usg-disa-stig.md", "", "<<DOESNT_EXIST>>"],
         ["doc/man7/usg-rules.md", rules_doc, "<<USG_MAN_RULES_PLACEHOLDER>>"],
         ["doc/man7/usg-variables.md", vars_doc,
          "<<USG_MAN_VARIABLE_PLACEHOLDER>>"]

--- a/tools/build_config.ini
+++ b/tools/build_config.ini
@@ -1,6 +1,6 @@
 [DEFAULT]
 # Package Version
-version=22.04.6
+version=22.04.7
 
 # Used for package alternatives, ie "usg-benchmarks-<this>"
 alternative_version=1


### PR DESCRIPTION
## Changelog

#### New profile STIG V1R1
The release comes with a new profile `disa_stig`, providing automated compliance with the DISA STIG V1R1 for Ubuntu 22.04 LTS, released on 2024-04-10.

For more information, including the usage and implementation limitations, please see the manuals:
```
man 8 usg
man 7 usg-disa-stig
```

#### Fixes and improvements for CIS profile

- Fix non-idempotent bash remediation for sysctl template (LP: #2056150)
- Add missing !package_cups_removed to cis_level1 profile (LP: #2057945)
- Fix handling of grub.d configs in grub2_bootloader_argument
- Fix check for accounts_user_dot_no_world_writable_programs
- Fix remediations on config files without trailing newlines (LP: #2061072)
- Modify dconf package name to fix false positives in dconf rules
- Enable dconf profiles in bash remediation of dconf rules
- Fix SCE check for iptables_open_ports (LP: #2061213)
- Fix SCE checks for iptables_loopback_traffic (LP: #2061215)
- Add missing rule package_pam_pwquality_installed (LP: #2065113)
- Disable all remediation languages except bash in compiled benchmarks
- Add a warning to sshd_limit_user_access
- Fix check for non-existing audispd in aide_check_audit_tools

#### Known issues

- The CIS profile now contains the additional rule  `package_pam_pwquality_installed`, which will be automatically selected when using an older tailoring file, installing the `libpam-pwquality` package if not present and thus enforcing stricter password requirements. If this rule shuold be disabled in your environment, please recreate and adjust the tailoring file accordingly.

