### PR TITLE
[focal] Fix test if tailoring_file variable is set

### DIFF
--- a/sbin/usg
+++ b/sbin/usg
@@ -360,7 +360,7 @@ if [ $? -gt 0 ]; then
 fi
 
 # If command-line contains no profile or tailoring file, try to use the default tailoring file
-if [ ! -v "$tailoring_file" ] && [ -z "$1" ]; then
+if [ ! -v tailoring_file ] && [ -z "$1" ]; then
     if [ -f $DEFAULT_TAILORING ]; then
         echo "Using the default tailoring file at $DEFAULT_TAILORING"
         tailoring_file=$DEFAULT_TAILORING


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/usg/+bug/2095162