### PR TITLE
Release 22.04.10

### DIFF
--- a/README.build
+++ b/README.build
@@ -79,8 +79,8 @@ update the documentation, without any manual intervention required.
 
 * STEP 3. Update the tailoring files
 All the current tailoring files are located into the tailoring subdirectory.
-Four are associated with CIS profiles (cis_level{1,2}_{server,workstation}-tailoring.xml)
-while a single one (stig-tailoring.xml) is associated with DISA-STIG.
+Five are associated with CIS profiles (cis_level{1,2}_{server,workstation}-tailoring.xml and 
+cis_level1_server_ec2-tailoring.xml) while a single one (stig-tailoring.xml) is associated with DISA-STIG.
 
 The tools/ directory provides the `generate_tailoring_file.py` script, which
 can be used to help update the aforementioned tailoring files. For
@@ -111,7 +111,7 @@ So, update the value to the same value used in Step 2:
 ...
 
 
-Repeat the aforementioned procedure for the other 3 CIS profiles and for the single DISA-STIG
+Repeat the aforementioned procedure for the other 4 CIS profiles and for the single DISA-STIG
 profile.
 
 ** When this step must be done?

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,18 @@
+ubuntu-security-guides-enhanced (22.04.10) jammy; urgency=medium
+
+  * Add custom EC2 profile based on CIS Level 1 Server
+  * CaC content: Multiple fixes and improvements
+    - Disable unapplicable auditd rules on aarch64
+    - Ensure correct umask when creating sssd.conf
+    - Remove rule disable_ctrlaltdel_burstaction from STIG profile
+    - Fix rule auditd_rules_mac_modification to monitor apparmor directories
+    - Replace unmask with mask in socket_systemd-journal-remote_disabled
+  * USG tool: minor fixes
+    - fix invalid precedence for default tailoring file (LP: #2095162)
+    - align --tailoring-file usage documentation with the implementation
+
+ -- Miha Purg <miha.purg@canonical.com>  Thu, 30 Jan 2024 13:12:11 +0100
+
 ubuntu-security-guides-enhanced (22.04.9) jammy; urgency=medium
 
   * CaC content: Multiple fixes and improvements

--- a/sbin/usg
+++ b/sbin/usg
@@ -364,7 +364,7 @@ if [ $? -gt 0 ]; then
 fi
 
 # If command-line contains no profile or tailoring file, try to use the default tailoring file
-if [ ! -v "$tailoring_file" ] && [ -z "$1" ]; then
+if [ ! -v tailoring_file ] && [ -z "$1" ]; then
     if [ -f $DEFAULT_TAILORING ]; then
         echo "Using the default tailoring file at $DEFAULT_TAILORING"
         tailoring_file=$DEFAULT_TAILORING

--- a/sbin/usg
+++ b/sbin/usg
@@ -93,8 +93,8 @@ with either a provided profile or a provided tailoring file.
 
 Available options are:
 	--tailoring-file <path to file>     Provides a tailoring file
-					    instead of a profile. Any
-					    profile provided is ignored"
+					    instead of a profile.
+"
 usage_common_options
 
 echo "Unless the --tailoring-file flag is provided, a profile must be given." 1>&2
@@ -120,8 +120,8 @@ reliable report.
 
 Available options are:
 	--tailoring-file <path to file>     Provides a tailoring file
-					    instead of a profile. Any
-					    profile provided is ignored"
+					    instead of a profile.
+"
 
 usage_common_options
 
@@ -143,8 +143,7 @@ Available options are:
 					    to the provided path. Default
 					    is standard output.
 	--tailoring-file <path to file>     Provides a tailoring file
-					    instead of a profile. Any
-					    profile provided is ignored
+					    instead of a profile.
 "
 
 echo "Unless the --tailoring-file flag is provided, a profile must be given." 1>&2

--- a/sbin/usg
+++ b/sbin/usg
@@ -28,7 +28,8 @@ declare -A PROFILES=( ["cis_level1_server"]="cis_level1_server-tailoring.xml" \
                       ["cis_level2_server"]="cis_level2_server-tailoring.xml" \
                       ["cis_level1_workstation"]="cis_level1_workstation-tailoring.xml" \
                       ["cis_level2_workstation"]="cis_level2_workstation-tailoring.xml" \
-                      ["disa_stig"]="stig-tailoring.xml" )
+                      ["disa_stig"]="stig-tailoring.xml" \
+                      ["cis_level1_server_ec2"]="cis_level1_server_ec2.xml" )
 
 BASE_DIR="/usr/share/ubuntu-scap-security-guides/current"
 TAILORING_DIR="$BASE_DIR/tailoring"

--- a/templates/doc/man7/usg-cis.md
+++ b/templates/doc/man7/usg-cis.md
@@ -6,7 +6,7 @@
 usg-cis - Information on CIS profiles implementation
 
 # INTRODUCTION
-As mentioned in the **usg-rules**(8) man page, four CIS profiles are available to be audited/applied: **cis_level1_server**, **cis_level2_server**, **cis_level1_workstation** and **cis_level2_workstation**
+As mentioned in the **usg-rules**(8) man page, five CIS profiles are available to be audited/applied: **cis_level1_server**, **cis_level2_server**, **cis_level1_workstation**, **cis_level2_workstation**, and **cis_level1_ec2**
 
 This man page provides additional information on all four and explain how to customize some variables in order to properly match the CIS requirements.
 
@@ -31,7 +31,7 @@ accessible, since, by default, the root user is locked in Ubuntu.
 Also, note that level 2 profiles are an extension of level 1 profiles: **all rules applied on level 1 are also applied on level 2**.
 
 ## Profiles Targets
-This is self-explanatory: server profiles are made for Canonical Ubuntu Server images, while Workstation profiles are made for Workstation images, which generally implies the use of a graphical interface.
+This is self-explanatory: server profiles are made for Canonical Ubuntu Server images, while Workstation profiles are made for Workstation images, which generally implies the use of a graphical interface. The ec2 profile is a variant of the server profile that largely serves to remove some rules that do not apply to an ec2 environment.
 
 # CUSTOMIZING VARIABLES AFFECTING THE CIS PROFILES IMPLEMENTATIONS
 Some rules can be fine-tuned by changing their variables. However, CIS benchmarks provides some variables with phony parameters which **must be customized** so the hardening scripts can be properly applied and the audit can properly check them.

--- a/templates/doc/man7/usg-cis.md
+++ b/templates/doc/man7/usg-cis.md
@@ -6,7 +6,7 @@
 usg-cis - Information on CIS profiles implementation
 
 # INTRODUCTION
-As mentioned in the **usg-rules**(8) man page, five CIS profiles are available to be audited/applied: **cis_level1_server**, **cis_level2_server**, **cis_level1_workstation**, **cis_level2_workstation**, and **cis_level1_ec2**
+As mentioned in the **usg-rules**(8) man page, five CIS profiles are available to be audited/applied: **cis_level1_server**, **cis_level2_server**, **cis_level1_workstation**, **cis_level2_workstation**, and **cis_level1_server_ec2**
 
 This man page provides additional information on all four and explain how to customize some variables in order to properly match the CIS requirements.
 

--- a/templates/doc/man8/usg.md
+++ b/templates/doc/man8/usg.md
@@ -16,7 +16,7 @@ usg - Audit and remediation tool for security benchmarks compliance automatizati
 
 **usg** **generate-tailoring** **profile** **filename**
 
-Available profiles: *cis_level1_server* | *cis_level2_server* | *cis_level1_workstation* | *cis_level2_workstation* | *stig*
+Available profiles: *cis_level1_server* | *cis_level2_server* | *cis_level1_workstation* | *cis_level2_workstation* | *stig* | *cis_level1_server_ec2*
 
 # DESCRIPTION
 **usg**, short for Ubuntu Security Guide, is a tool to audit and comply with security guides such as CIS and DISA-STIG.
@@ -212,7 +212,7 @@ Note, however, that if the **tailoring-file** option is not provided, the user *
 See more info on **Tailoring Files** on the same-name section.
 
 ### Additional Info on Profiles
-CIS Profiles (**cis_level1_server**, **cis_level2_server**, **cis_level1_workstation** and **cis_level2_workstation**)
+CIS Profiles (**cis_level1_server**, **cis_level2_server**, **cis_level1_workstation**, **cis_level2_workstation**, **cis_level1_server_ec2)
 : Level 1 profiles have smaller usability impact than their level 2 counterparts.
 : Server profiles are made for Canonical Ubuntu Server images, while Workstation profiles are made for Workstation images, which generally implies the use of a graphical interface.
 

--- a/templates/tailoring/cis_level1_server_ec2-tailoring.xml
+++ b/templates/tailoring/cis_level1_server_ec2-tailoring.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Tailoring xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_scap-workbench_tailoring_default">
+  <benchmark href="PLACEHOLDER"/>
+  <version time="PLACEHOLDER">1</version>
+  <Profile id="xccdf_org.ssgproject.content_profile_cis_level1_server_ec2_customized"
+      extends="xccdf_org.ssgproject.content_profile_cis_level1_server_ec2">
+    <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 22.04 Level 1 Server Benchmark - EC2 [CUSTOMIZED]</title>
+    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 22.04 LTS Benchmark, v1.0.0, released 08-30-2022. The EC2 profile is a strict subset of the Level 1 Server profile tailored for Amazon EC2 images.</description>
+  </Profile>
+</Tailoring>

--- a/tools/build.py
+++ b/tools/build.py
@@ -178,6 +178,7 @@ def gen_tailoring(cac_directory, usg_directory, target, benchmark_version):
         "cis_level1_workstation.profile",
         "cis_level2_server.profile",
         "cis_level2_workstation.profile",
+        "cis_level1_server_ec2.profile",
         "stig.profile"]
 
     tailoring_template = [
@@ -185,6 +186,7 @@ def gen_tailoring(cac_directory, usg_directory, target, benchmark_version):
         "templates/tailoring/cis_level1_workstation-tailoring.xml",
         "templates/tailoring/cis_level2_server-tailoring.xml",
         "templates/tailoring/cis_level2_workstation-tailoring.xml",
+        "templates/tailoring/cis_level1_server_ec2-tailoring.xml",
         "templates/tailoring/stig-tailoring.xml"]
 
     gen_tailoring_script = "%s/generate_tailoring_file.py" % (tools_directory)

--- a/tools/build_config.ini
+++ b/tools/build_config.ini
@@ -1,6 +1,6 @@
 [DEFAULT]
 # Package Version
-version=22.04.9
+version=22.04.10
 
 # Used for package alternatives, ie "usg-benchmarks-<this>"
 alternative_version=1

--- a/tools/create_rule_and_variable_doc.py
+++ b/tools/create_rule_and_variable_doc.py
@@ -145,6 +145,7 @@ def main(args):
                 'cis_level2_server.profile',
                 'cis_level1_workstation.profile',
                 'cis_level2_workstation.profile',
+                'cis_level1_server_ec2.profile',
                 'stig.profile']
     usage = f'Usage: {args[0]} [ rules | variables ] <profile path> <xccdf file path>'
 


### PR DESCRIPTION
### Release info

- Minor fixes and improvements in CaC content and USG tool
- Backwards compatible with existing tailoring files
- Introduces a new profile `cis_level1_server_ec2` tailored for EC2 images

### Changelog

  * Add custom EC2 profile based on CIS Level 1 Server
  * CaC content: Multiple fixes and improvements
    - Disable unapplicable auditd rules on aarch64
    - Ensure correct umask when creating sssd.conf
    - Remove rule disable_ctrlaltdel_burstaction from STIG profile
    - Fix rule auditd_rules_mac_modification to monitor apparmor directories
    - Replace unmask with mask in socket_systemd-journal-remote_disabled
  * USG tool: minor fixes
    - fix invalid precedence for default tailoring file (LP: #2095162)
    - align --tailoring-file usage documentation with the implementation