### PR TITLE
Release 24.04.2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,17 @@
+ubuntu-security-guides-enhanced (24.04.2) noble; urgency=medium
+
+  * CaC content: Fixes and improvements
+    - Fix dconf key in rule dconf_gnome_screensaver_idle_delay
+    - Disable remediation for set_iptables_default_rule and
+      set_ip6tables_default_rule (LP: #2100814)
+    - Improve rule descriptions containing chown/chgrp commands
+    - Switch to using usernames instead of UIDs in file_owner_* rules (LP: #2098304)
+    - Disable symlink derefernce in rules accounts_user_dot_user_ownership
+      and accounts_user_dot_group_ownership
+
+ -- Miha Purg <miha.purg@canonical.com>  Mon, 17 Mar 2025 11:07:24 +0100
+
+
 ubuntu-security-guides-enhanced (24.04.1) noble; urgency=medium
 
   * Initial release of USG for Ubuntu 24.04 with CIS v1.0.0 profiles

--- a/tools/build_config.ini
+++ b/tools/build_config.ini
@@ -1,6 +1,6 @@
 [DEFAULT]
 # Package Version
-version=24.04.1
+version=24.04.2
 
 # Used for package alternatives, ie "usg-benchmarks-<this>"
 alternative_version=1


### PR DESCRIPTION
#### Release info

- Fixes and improvements in CaC content
- Backwards compatible with existing tailoring files

#### Changelog
  * CaC content: Fixes and improvements
    - Fix dconf key in rule dconf_gnome_screensaver_idle_delay
    - Disable remediation for set_iptables_default_rule and
      set_ip6tables_default_rule (LP: #2100814)
    - Improve rule descriptions containing chown/chgrp commands
    - Switch to using usernames instead of UIDs in file_owner_* rules (LP: #2098304)
    - Disable symlink derefernce in rules accounts_user_dot_user_ownership
      and accounts_user_dot_group_ownership