### PR TITLE
Release 20.04.23

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+ubuntu-security-guides-enhanced (20.04.23) focal; urgency=medium
+
+  * CaC content: Exclude system accounts in file_ownership_binary_dirs to
+      align with STIG rule UBTU-20-010457 (LP: #2103469)
+
+ -- Miha Purg <miha.purg@canonical.com>  Wed, 19 Mar 2025 17:49:10 +0100
+
 ubuntu-security-guides-enhanced (20.04.22) focal; urgency=medium
 
   * CaC content: Multiple fixes

--- a/tools/build_config.ini
+++ b/tools/build_config.ini
@@ -1,6 +1,6 @@
 [DEFAULT]
 # Package Version
-version=20.04.22
+version=20.04.23
 
 # Used for package alternatives, ie "usg-benchmarks-<this>"
 alternative_version=2


### PR DESCRIPTION
#### Release info
- Fix in CaC content
- Backwards compatible with existing tailoring files

#### Changelog:

  * CaC content: Exclude system accounts in file_ownership_binary_dirs to
      align with STIG rule UBTU-20-010457 (fixes https://bugs.launchpad.net/usg/+bug/2103469)