### PR TITLE
Release 20.04.23

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,12 @@
 ubuntu-security-guides-enhanced (20.04.23) focal; urgency=medium
 
-  * CaC content: Exclude system accounts in file_ownership_binary_dirs to
+  * CaC content:
+    - Exclude system accounts in file_ownership_binary_dirs to
       align with STIG rule UBTU-20-010457 (LP: #2103469)
+    - Set file_permissions_var_log to NotApplicable if rsyslog
+      is enabled
 
- -- Miha Purg <miha.purg@canonical.com>  Wed, 19 Mar 2025 17:49:10 +0100
+ -- Miha Purg <miha.purg@canonical.com>  Fri, 21 Mar 2025 12:38:10 +0100
 
 ubuntu-security-guides-enhanced (20.04.22) focal; urgency=medium
 


### PR DESCRIPTION
#### Release info
- Fixes in CaC content
- Backwards compatible with existing tailoring files

#### Changelog:

  * CaC content:
    - Exclude system accounts in file_ownership_binary_dirs to
      align with STIG rule UBTU-20-010457 (LP: #2103469)
    - Set file_permissions_var_log to NotApplicable if rsyslog
      is enabled