### PR TITLE
Release 22.04.11

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,17 @@
+ubuntu-security-guides-enhanced (22.04.11) jammy; urgency=medium
+
+  * CaC content: Multiple fixes and improvements
+    - Update DISA STIG to V2R3
+    - Fix package applicability checks in remediations (LP: #2097443)
+    - Fix variable name var_password_pam_unix_premember (LP: #2097448)
+    - Align file_groupownership_system_commands with STIG (LP: #2098305)
+    - Fix remediation for accounts_user_dot_user_ownership
+    - 
+  * USG tool: minor fixes
+    - fix mapping for ec2 tailoring file
+
+ -- Miha Purg <miha.purg@canonical.com>  Thu, 12 Mar 2025 13:58:00 +0100
+
 ubuntu-security-guides-enhanced (22.04.10) jammy; urgency=medium
 
   * Add custom EC2 profile based on CIS Level 1 Server
@@ -11,7 +25,7 @@ ubuntu-security-guides-enhanced (22.04.10) jammy; urgency=medium
     - fix invalid precedence for default tailoring file (LP: #2095162)
     - align --tailoring-file usage documentation with the implementation
 
- -- Miha Purg <miha.purg@canonical.com>  Thu, 30 Jan 2024 13:12:11 +0100
+ -- Miha Purg <miha.purg@canonical.com>  Thu, 30 Jan 2025 13:12:11 +0100
 
 ubuntu-security-guides-enhanced (22.04.9) jammy; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -15,10 +15,11 @@ ubuntu-security-guides-enhanced (22.04.11) jammy; urgency=medium
     - Fix accounts_user_dot_user/group_ownership to not dereference symlinks
     - Override the /etc/dpkg path-exclude option for some cloud provider's images
     - Fix applicability for file_permissions_var_log
+    - Disable remediation for file_ownership_binary_dirs
   * USG tool: minor fixes
     - fix mapping for ec2 tailoring file
 
- -- Alan Moore <alan.moore@canonical.com>  Mon, 31 Mar 2025 11:36:28 +0100
+ -- Alan Moore <alan.moore@canonical.com>  Tue, 01 Apr 2025 12:13:46 +0100
 
 ubuntu-security-guides-enhanced (22.04.10) jammy; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,16 +1,24 @@
 ubuntu-security-guides-enhanced (22.04.11) jammy; urgency=medium
 
+  [ Miha Purg ]
   * CaC content: Multiple fixes and improvements
     - Update DISA STIG to V2R3
     - Fix package applicability checks in remediations (LP: #2097443)
     - Fix variable name var_password_pam_unix_premember (LP: #2097448)
     - Align file_groupownership_system_commands with STIG (LP: #2098305)
     - Fix remediation for accounts_user_dot_user_ownership
-    - 
+    - Remove non-compliant MACs
+    - Add Ubuntu 22.04 to the list of FIPS certified OS
+    - Fix dconf key for idle-delay lock on Ubuntu
+    - Disable remediations for set_iptables_default_rule and set_ip6tables_default_rule disable remediation iptables
+    - Align chronyd makestep value with Ubuntu STIGs
+    - Fix accounts_user_dot_user/group_ownership to not dereference symlinks
+    - Override the /etc/dpkg path-exclude option for some cloud provider's images
+    - Fix applicability for file_permissions_var_log
   * USG tool: minor fixes
     - fix mapping for ec2 tailoring file
 
- -- Miha Purg <miha.purg@canonical.com>  Thu, 12 Mar 2025 13:58:00 +0100
+ -- Alan Moore <alan.moore@canonical.com>  Mon, 31 Mar 2025 11:36:28 +0100
 
 ubuntu-security-guides-enhanced (22.04.10) jammy; urgency=medium
 

--- a/tools/build_config.ini
+++ b/tools/build_config.ini
@@ -1,6 +1,6 @@
 [DEFAULT]
 # Package Version
-version=22.04.10
+version=22.04.11
 
 # Used for package alternatives, ie "usg-benchmarks-<this>"
 alternative_version=1


### PR DESCRIPTION
### Release info

- Update DISA STIG to V2R3
- Minor fixes and improvements in CaC content and USG tool
- Backwards compatible with existing tailoring files

### Changelog

  * CaC content: Multiple fixes and improvements
    - Update DISA STIG to V2R3
    - Fix package applicability checks in remediations (LP: #2097443)
    - Fix variable name var_password_pam_unix_premember (LP: #2097448)
    - Align file_groupownership_system_commands with STIG (LP: #2098305)
    - Fix remediation for accounts_user_dot_user_ownership
    - Remove non-compliant MACs
    - Add Ubuntu 22.04 to the list of FIPS certified OS
    - Fix dconf key for idle-delay lock on Ubuntu
    - Disable remediations for set_iptables_default_rule and set_ip6tables_default_rule disable remediation iptables
    - Align chronyd makestep value with Ubuntu STIGs
    - Fix accounts_user_dot_user/group_ownership to not dereference symlinks
    - Override the /etc/dpkg path-exclude option for some cloud provider's images
    - Fix applicability for file_permissions_var_log
    - Disable remediation for file_ownership_binary_dirs
  * USG tool: minor fixes
    - fix mapping for ec2 tailoring file