### PR TITLE
Version 22.04.13

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+ubuntu-security-guides-enhanced (22.04.13) jammy; urgency=medium
+
+  * CaC content:
+    - Use chrony instead of timesyncd in EC2 profile by default
+    - Fix maxdepth in file_owner and file_groupowner templates
+
+ -- Miha Purg <miha.purg@canonical.com>  Wed, 20 Aug 2025 09:41:57 +0200
+
 ubuntu-security-guides-enhanced (22.04.12) jammy; urgency=medium
 
   [Alan Moore]

--- a/tools/build_config.ini
+++ b/tools/build_config.ini
@@ -1,6 +1,6 @@
 [DEFAULT]
 # Package Version
-version=22.04.12
+version=22.04.13
 
 # Used for package alternatives, ie "usg-benchmarks-<this>"
 alternative_version=1


### PR DESCRIPTION
## Release info
- Change in default NTP client from timesyncd to chrony in profile `cis_level1_server_ec2`
- Hotfix for rules `file_owner_var_log` and `file_groupowner_var_log` (STIG only) to only set ownership of `/var/log/` and not its subdirectories
- Backwards compatible with existing tailoring files

## Changelog
  * CaC content:
    - Use chrony instead of timesyncd in EC2 profile by default
    - Fix maxdepth in file_owner and file_groupowner templates