### PR TITLE
Fix acquire_lock error handling

### DIFF
--- a/src/usg/cli.py
+++ b/src/usg/cli.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 from usg import constants
 from usg.config import load_config, override_config_with_cli_args
-from usg.exceptions import StateFileError, USGError
+from usg.exceptions import StateFileError, USGError, LockError
 from usg.models import Benchmark, Profile, TailoringFile
 from usg.usg import USG
 from usg.utils import acquire_lock, validate_perms
@@ -645,6 +645,10 @@ def cli() -> None:
     """Load configuration, parse args, run USG commands."""
     if os.geteuid() != 0:
         error_exit("Error: this script must be run with super-user privileges.")
+    try:
+        acquire_lock()
+    except LockError as e:
+        error_exit(str(e))
 
     # load config from defaults or file if exists
     config = load_config(constants.CONFIG_PATH)
@@ -686,7 +690,6 @@ def cli() -> None:
 
 def main() -> None:
     """CLI entry point. Call cli() and catch runtime errors."""
-    acquire_lock()
     try:
         cli()
     except KeyboardInterrupt:

--- a/src/usg/exceptions.py
+++ b/src/usg/exceptions.py
@@ -42,3 +42,6 @@ class FileMoveError(USGError):
 
 class StateFileError(USGError):
     """Error reading or writing to USG state file."""
+
+class LockError(USGError):
+    """Failed to acquire lock on file."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,6 +28,7 @@ def patch_usg_and_cli(tmp_path_factory, dummy_benchmarks):
     mp.setattr(constants_module, "BENCHMARK_METADATA_PATH", dummy_benchmarks)
     mp.setattr(constants_module, "STATE_DIR", tmp_state_dir)
     mp.setattr(constants_module, "CLI_STATE_FILE", tmp_state_dir / "state.json")
+    mp.setattr(constants_module, "LOCK_PATH", tmp_state_dir / "usg.lock")
 
     from usg import usg as usg_module
 
@@ -341,6 +342,7 @@ def test_benchmark_version_state_integration(patch_usg_and_cli, capsys, monkeypa
     importlib.reload(cli)
     monkeypatch.setattr(cli, "USG", DummyUSG)
     monkeypatch.setattr(cli.os, "geteuid", lambda: 0)
+    monkeypatch.setattr(cli, "acquire_lock", lambda: None)
 
     from usg.cli import load_benchmark_version_state
 


### PR DESCRIPTION
Fixes issue with acquire_lock raising an exception when run as non-root user or in rare situations where the lock file cannot be created as root. 

Changes:
- lock is acquired only after checking running user is root
- acquire_lock function is called from inside cli() to gracefully handle uncaught errors
- the program now fails only if the lock cannot be acquired, not if it cannot be created