### PR TITLE
Version 20.04.24

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+ubuntu-security-guides-enhanced (20.04.24) focal; urgency=medium
+
+  * CaC content:
+    - Add oval check to rule prevent_direct_root_logins
+    - Fix config priority for rule rsyslog_filecreatemode (LP: #2107530)
+    - Fix maxdepth in file_owner and file_groupowner templates
+    - Disable symlink dereference in file_owner and file_groupowner templates
+
+ -- Miha Purg <miha.purg@canonical.com>  Thu, 25 Sep 2025 14:50:01 +0200
+
 ubuntu-security-guides-enhanced (20.04.23) focal; urgency=medium
 
   * CaC content:

--- a/tools/build_config.ini
+++ b/tools/build_config.ini
@@ -1,6 +1,6 @@
 [DEFAULT]
 # Package Version
-version=20.04.23
+version=20.04.24
 
 # Used for package alternatives, ie "usg-benchmarks-<this>"
 alternative_version=2


### PR DESCRIPTION
#### Release info
- Fixes in CaC content
- Backwards compatible with existing tailoring files

#### Changelog
  * CaC content:
    - Add oval check to rule prevent_direct_root_logins
    - Fix config priority for rule rsyslog_filecreatemode (LP: #2107530)
    - Fix maxdepth in file_owner and file_groupowner templates
    - Disable symlink dereference in file_owner and file_groupowner templates