### PR TITLE
Improve cli ux

### DIFF
--- a/debian/tests/usg-cli-e2e
+++ b/debian/tests/usg-cli-e2e
@@ -42,9 +42,9 @@ test_cmd "usg --version"  0  "\d*\.\d*\.\d*"                 ""
 test_cmd "usg list --all"                            0  "cis_level1_server"             ""
 test_cmd "usg list --all | grep 'Listing available'" 0  "Listing available profiles"             ""
 
-# only names should exist with --names-only
-test_cmd "usg list --names-only"                            0  "cis_level1_server"             ""
-test_cmd "usg list --names-only | grep 'Listing available'" 1  ""                              ""
+# machine-readable flag should print "profile:type:product:..." and no extra information
+test_cmd "usg list --machine-readable"                            0  "cis_level1_server:CIS:"             ""
+test_cmd "usg list --machine-readable | grep 'Listing available'" 1  ""                              ""
 
 # info for profile should work
 test_cmd "usg info cis_level1_server"  0  "Benchmark.*CIS"   ""

--- a/debian/usg.bash-completion
+++ b/debian/usg.bash-completion
@@ -26,7 +26,7 @@ _usg_completions() {
 
     # Get list of available profiles
     usg_profile_list() {
-        usg list --names-only 2>/dev/null | xargs
+        usg list --machine-readable 2>/dev/null | cut -d: -f1 | xargs
     }
 
     # Add mutually exclusive args --tailoring-file (optional) and <profile> (1st positional)

--- a/src/usg/cli.py
+++ b/src/usg/cli.py
@@ -632,7 +632,7 @@ def parse_args(config_defaults: configparser.ConfigParser) -> argparse.Namespace
                 help="List deprecated profiles",
             )
             cmd_parser.add_argument(
-                "-n",
+                "-m",
                 "--machine-readable",
                 action="store_true",
                 default=False,

--- a/src/usg/cli.py
+++ b/src/usg/cli.py
@@ -142,7 +142,7 @@ def error_exit(msg: str = "", rc: int = 1) -> None:
 def command_list(usg: USG, args: argparse.Namespace) -> None:
     """List available profiles."""
     logger.debug("Starting command_list")
-    if not args.names_only:
+    if not args.machine_readable:
         print("Listing available profiles...\n")
         print(CLI_LIST_FORMAT.format("PROFILE", "BENCHMARK/PRODUCT", "VERSION"))
 
@@ -153,8 +153,16 @@ def command_list(usg: USG, args: argparse.Namespace) -> None:
         if not latest and not args.all:
             continue
 
-        if args.names_only:
-            print(p.profile_id)
+        if args.machine_readable:
+            print(":".join([
+                p.profile_id,
+                benchmark.benchmark_type,
+                benchmark.product,
+                benchmark.version,
+                p.benchmark_id,
+                "", "", "", "", "", "" # reserved
+                ]))
+
         else:
             depr = "" if latest else " *deprecated*"
             print(
@@ -164,7 +172,7 @@ def command_list(usg: USG, args: argparse.Namespace) -> None:
                     benchmark.version + depr,
                 )
             )
-    if not args.names_only:
+    if not args.machine_readable:
         print("""
 
 Use 'usg info' to print information about a specific profile or tailoring file:
@@ -620,10 +628,10 @@ def parse_args(config_defaults: configparser.ConfigParser) -> argparse.Namespace
             )
             cmd_parser.add_argument(
                 "-n",
-                "--names-only",
+                "--machine-readable",
                 action="store_true",
                 default=False,
-                help="Show only profiles names",
+                help="Machine readable output",
             )
 
         cmd_parser.add_argument(

--- a/src/usg/usg.py
+++ b/src/usg/usg.py
@@ -156,8 +156,8 @@ class USG:
 
         raise ProfileNotFoundError(
             f"No profile found matching these criteria: "
-            f"profile={profile_id}, product={product}, "
-            f"version={benchmark_version}."
+            f"name: '{profile_id}', product: '{product}', "
+            f"version: '{benchmark_version}'."
         )
 
     def load_tailoring(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -125,7 +125,7 @@ def test_cli_non_root_user(monkeypatch, capsys):
         (["list"], "Listing available profiles...", None, None),
         (["list", "asd"], None, "unrecognized arguments: asd", 2),
         (["list", "--all"], "v1.0.0", None, None),
-        (["list", "--names-only"], "cis_level1_server", None, None),        
+        (["list", "--machine-readable"], "cis_level1_server:CIS:ubuntu2404:v2.0.0", None, None),
         (["list"], "v2.0.0", None, None),
         # successfulcommands with profile argument
         (["info", "cis_level1_server"], "ubuntu2404_CIS_3", None, None),
@@ -231,7 +231,7 @@ def test_cli_generate_tailoring(
     <select idref="xccdf_org.ssgproject.content_rule_test_rule" selected="true"/>
     </Profile>
 </Tailoring>""")
-    
+
     sys.argv = ["usg", *cli_args]
 
     cli.cli()
@@ -256,7 +256,7 @@ def test_load_benchmark_version_state(tmp_path, monkeypatch):
         }
     }))
     assert load_benchmark_version_state("cis_level1_server") == "test_version"
-    
+
     # missing benchmark profile defaults to "latest" version
     assert load_benchmark_version_state("missing_profile") == "latest"
 
@@ -270,7 +270,7 @@ def test_load_benchmark_version_state_error(tmp_path, monkeypatch):
     Path(state_file).write_text("test")
     with pytest.raises(StateFileError, match="Corrupted"):
         load_benchmark_version_state("cis_level1_server")
-    
+
     # bad data
     Path(state_file).write_text(json.dumps({
         "bad_key_for_benchmark_versions": {
@@ -279,7 +279,7 @@ def test_load_benchmark_version_state_error(tmp_path, monkeypatch):
     }))
     with pytest.raises(StateFileError, match="Corrupted"):
         load_benchmark_version_state("cis_level1_server")
-   
+
 
 def test_save_benchmark_version_state(tmp_path, monkeypatch):
     # Test that benchmark version state is stored correctly to state file
@@ -316,7 +316,7 @@ def test_save_benchmark_version_state_corrupted_error(tmp_path, monkeypatch):
 
 def test_benchmark_version_state_integration(patch_usg_and_cli, capsys, monkeypatch, tmp_path):
     # test that cli commands retain benchmark version across runs
-     
+
     # hack to undo monkepatches to load/save_state functions done in patch_usg_and_cli
     from usg.cli import USG as DummyUSG
     importlib.reload(cli)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -147,6 +147,11 @@ def test_cli_non_root_user(monkeypatch, capsys):
         (["audit"], None, "Error: a profile or a tailoring file must be provided.", 2),
         (["fix"], None, "Error: a profile or a tailoring file must be provided.", 2),
         (["generate-fix"], None, "Error: a profile or a tailoring file must be provided.", 2),
+        # failed commands with profile and bad version
+        (["info", "cis_level1_server", "-b", "v10"], None, "No profile found matching", 1),
+        (["audit", "cis_level1_server", "-b", "v10"], None, "No profile found matching", 1),
+        (["fix", "cis_level1_server", "-b", "v10"], None, "No profile found matching", 1),
+        (["generate-fix", "cis_level1_server", "-b", "v10"], None, "No profile found matching", 1),
         # failed commands with both a profile and a tailoring file
         (["info", "cis_level1_server", "-t", "tailoring.xml"], None, "You cannot provide both a tailoring file and a profile!", 2),
         (["audit", "cis_level1_server", "-t", "tailoring.xml"], None, "You cannot provide both a tailoring file and a profile!", 2),


### PR DESCRIPTION
Small adjustments to cli:
- cleaner error message when using bad profile name/version, with added suggestion to run `usg list`
- add examples to subcommand usage (e.g. `$ usg audit cis_level1_server`)
- improve machine readable profile listing and switch from --names-only to --machine-readable