### PR TITLE
Loosen file permission restrictions

### DIFF
--- a/src/usg/backends.py
+++ b/src/usg/backends.py
@@ -8,9 +8,9 @@ import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import ClassVar
 
-from usg.exceptions import BackendCommandError, BackendError, PermValidationError
+from usg.exceptions import BackendCommandError, BackendError
 from usg.results import AuditResults, BackendArtifacts
-from usg.utils import validate_perms
+from usg.utils import check_perms
 
 logger = logging.getLogger(__name__)
 
@@ -120,23 +120,13 @@ class OpenscapBackend:
         self._oscap_path = Path(openscap_bin_path).resolve()
 
         # do sanity checks on oscap binary and work_dir
-        try:
-            validate_perms(self._oscap_path)
-        except PermValidationError as e:
-            raise BackendError(
-                f"Permission issue with Openscap binary: {e}",
-            ) from e
+        check_perms(self._oscap_path)
         if not os.access(self._oscap_path, os.X_OK):
             raise BackendError(
                 f"Openscap binary '{self._oscap_path}' is not executable.",
             )
 
-        try:
-            validate_perms(self._work_dir, is_dir=True)
-        except PermValidationError as e:
-            raise BackendError(
-                f"Permission issue with temporary work directory: {e}",
-            ) from e
+        check_perms(self._work_dir, is_dir=True)
 
         self._oscap_version = self._get_oscap_version(
             self._oscap_path, self._work_dir

--- a/src/usg/cli.py
+++ b/src/usg/cli.py
@@ -14,10 +14,12 @@ from pathlib import Path
 
 from usg import constants
 from usg.config import load_config, override_config_with_cli_args
-from usg.exceptions import LockError, ProfileNotFoundError, StateFileError, USGError
+from usg.exceptions import (
+        LockError, ProfileNotFoundError, StateFileError, USGError
+        )
 from usg.models import Benchmark, Profile, TailoringFile
 from usg.usg import USG
-from usg.utils import acquire_lock, validate_perms
+from usg.utils import acquire_lock, check_perms
 from usg.version import __version__
 
 logger = logging.getLogger(__name__)
@@ -341,8 +343,8 @@ def load_benchmark_version_state(profile_id: str) -> str:
     cli_state_file = Path(constants.CLI_STATE_FILE)
     json_data = {}
     if cli_state_file.exists():
+        check_perms(cli_state_file)
         try:
-            validate_perms(cli_state_file)
             with cli_state_file.open("r") as f:
                 json_data.update(json.load(f))
             versions = json_data["benchmark_versions"]

--- a/src/usg/usg.py
+++ b/src/usg/usg.py
@@ -19,7 +19,7 @@ from usg.exceptions import (
 )
 from usg.models import Benchmark, Benchmarks, Profile, TailoringFile
 from usg.results import AuditResults, BackendArtifacts
-from usg.utils import gunzip_file, validate_perms, verify_integrity
+from usg.utils import gunzip_file, check_perms, verify_integrity
 
 logger = logging.getLogger(__name__)
 
@@ -55,14 +55,15 @@ class USG:
 
         # do sanity checks on important files
         try:
-            validate_perms(constants.BENCHMARK_METADATA_PATH)
+            check_perms(constants.BENCHMARK_METADATA_PATH)
         except MissingFileError as e:
             msg = (
                 f"Could not find benchmark data {constants.BENCHMARK_METADATA_PATH}. "
                 f"Please ensure the {constants.BENCHMARK_PKG} package is installed."
             )
             raise USGError(msg) from e
-        validate_perms(constants.STATE_DIR, is_dir=True)
+
+        check_perms(constants.STATE_DIR, is_dir=True)
 
         self._benchmarks = Benchmarks.from_json(constants.BENCHMARK_METADATA_PATH)
         self._timestamp = datetime.datetime.now().strftime("%Y%m%d.%H%M")  # noqa: DTZ005
@@ -178,7 +179,7 @@ class USG:
         """
         logger.debug(f"Loading {tailoring_file_path}")
 
-        validate_perms(tailoring_file_path)
+        check_perms(tailoring_file_path)
 
         tailoring = TailoringFile.from_file(tailoring_file_path)
 
@@ -211,7 +212,7 @@ class USG:
         ds_gz_file = benchmark.data_files["datastream_gz"]
         ds_gz_path = constants.BENCHMARK_METADATA_PATH.parent / ds_gz_file.rel_path
 
-        validate_perms(ds_gz_path)
+        check_perms(ds_gz_path)
 
         verify_integrity(ds_gz_path, ds_gz_file.sha256, "sha256")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,7 +21,7 @@ def patch_usg_and_cli(tmp_path_factory, dummy_benchmarks):
     # patch the usg module:
     # - set benchmarks to dummy benchmarks fixture
     # - set state_dir to a tmp path
-    # - set validate_perms and verify_integrity to no-ops
+    # - set check_perms and verify_integrity to no-ops
     # - patch USG with a dummy USG class overriding audit, generate_fix, fix
     # - change working directory to a tmp dir and create tailoring file in it
     # - patch load state functions to always return "latest" (always clean slate and no state file)
@@ -39,7 +39,7 @@ def patch_usg_and_cli(tmp_path_factory, dummy_benchmarks):
     mp.setattr(constants, "LOCK_PATH", tmp_state_dir / "usg.lock")
     mp.setattr(constants, "CLI_LOG_FILE", "usg.log")
 
-    mp.setattr(utils, "validate_perms", lambda *a, **k: None)
+    mp.setattr(utils, "check_perms", lambda *a, **k: None)
     mp.setattr(utils, "verify_integrity", lambda *a, **k: None)
 
     class DummyUSG(USG):

--- a/tests/test_usg.py
+++ b/tests/test_usg.py
@@ -43,7 +43,7 @@ def patch_usg(tmp_path_factory, dummy_benchmarks):
     # - set benchmarks to our dummy benchmarks
     # - set var_dir to our tmp path
     # - set OpenscapBackend to our dummy backend
-    # - set validate_perms, verify_integrity to no-ops
+    # - set check_perms, verify_integrity to no-ops
     # - set gunzip_file to no-op since anyhow using dummy backend
     #   which doesn't use the datastream
     # - set datetime to a fixed date
@@ -113,7 +113,7 @@ def patch_usg(tmp_path_factory, dummy_benchmarks):
     mp.setattr(constants, "BENCHMARK_METADATA_PATH", dummy_benchmarks)
     mp.setattr(constants, "STATE_DIR", tmp_path_factory.mktemp("var_dir"))
     mp.setattr(usg_module, "OpenscapBackend", DummyBackend)
-    mp.setattr(usg_module, "validate_perms", lambda *a, **k: None)
+    mp.setattr(usg_module, "check_perms", lambda *a, **k: None)
     mp.setattr(usg_module, "verify_integrity", lambda *a, **k: None)
     mp.setattr(usg_module, "gunzip_file", lambda *a, **k: None)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,8 +5,15 @@ import pytest
 import logging
 
 from usg import constants
-from usg.utils import acquire_lock, gunzip_file, verify_integrity, validate_perms
-from usg.exceptions import IntegrityError, PermValidationError, LockError
+from usg.utils import (
+        acquire_lock,
+        gunzip_file,
+        verify_integrity,
+        check_perms,
+        _has_good_ownership,
+        _is_world_writable
+        )
+from usg.exceptions import IntegrityError, LockError, MissingFileError
 
 
 def test_verify_integrity_success(tmp_path):
@@ -26,78 +33,82 @@ def test_verify_integrity_failure(tmp_path):
         verify_integrity(file, wrong_digest, "sha256")
 
 
-def test_validate_perms_file_ok(tmp_path):
+def test_check_perms_file_ok(tmp_path, caplog):
     file = tmp_path / "afile"
     file.touch()
-    os.chmod(file, mode=0o600)
-    # Should not raise
-    validate_perms(file)
+    os.chmod(file, mode=0o664)
+    os.chmod(tmp_path, mode=0o700)
+    with caplog.at_level("WARNING"):
+        check_perms(file)
+    assert "is world-writable" not in caplog.text
 
 
-def test_validate_perms_dir_ok(tmp_path):
+def test_check_perms_dir_ok(tmp_path, caplog):
     d = tmp_path / "adir"
     d.mkdir()
-    os.chmod(d, mode=0o700)
-    validate_perms(d, is_dir=True)
+    os.chmod(d, mode=0o775)
+    with caplog.at_level("WARNING"):
+        check_perms(d, is_dir=True)
+    assert "is world-writable" not in caplog.text
 
 
-def test_validate_perms_file_not_exist(tmp_path):
+def test_check_perms_file_not_exist(tmp_path):
     file = tmp_path / "doesnotexist"
-    with pytest.raises(PermValidationError):
-        validate_perms(file)
+    with pytest.raises(MissingFileError):
+        check_perms(file)
 
 
-def test_validate_perms_symlink(tmp_path):
-    link = tmp_path / "alink"
-    link.symlink_to(".")
-    with pytest.raises(PermValidationError):
-        validate_perms(link)
-
-
-def test_validate_perms_not_dir(tmp_path):
+def test_check_perms_not_dir(tmp_path):
     file = tmp_path / "afile"
     file.touch()
     os.chmod(file, mode=0o600)
-    with pytest.raises(PermValidationError):
-        validate_perms(file, is_dir=True)
+    with pytest.raises(MissingFileError):
+        check_perms(file, is_dir=True)
 
 
-def test_validate_perms_not_file(tmp_path):
+def test_check_perms_not_file(tmp_path):
     d = tmp_path / "adir"
     d.mkdir()
     os.chmod(d, mode=0o700)
-    with pytest.raises(PermValidationError):
-        validate_perms(d, is_dir=False)
+    with pytest.raises(MissingFileError):
+        check_perms(d, is_dir=False)
 
 
-def test_validate_perms_world_writable_file(tmp_path):
+def test_check_perms_world_writable_file(tmp_path, caplog):
     file = tmp_path / "afile"
     file.touch()
     os.chmod(file, mode=0o666)
-    with pytest.raises(PermValidationError):
-        validate_perms(file)
+    with caplog.at_level("WARNING"):
+        check_perms(file)
+    assert "is world-writable" in caplog.text
 
 
-def test_validate_perms_world_writable_dir(tmp_path):
+def test_check_perms_world_writable_dir(tmp_path, caplog):
     d = tmp_path / "adir"
     d.mkdir()
     os.chmod(d, mode=0o777)
-    with pytest.raises(PermValidationError):
-        validate_perms(d, is_dir=True)
+    with caplog.at_level("WARNING"):
+        check_perms(d, is_dir=True)
+    assert "is world-writable" in caplog.text
 
 
-def test_validate_perms_world_writable_parent(tmp_path):
+def test_check_perms_world_writable_parent(tmp_path, caplog):
     d = tmp_path / "parent"
     d.mkdir()
     file = d / "afile"
     file.touch()
-    os.chmod(d, mode=0o777)
     os.chmod(file, mode=0o600)
-    with pytest.raises(PermValidationError):
-        validate_perms(file)
+    os.chmod(d, mode=0o775)
+    with caplog.at_level("WARNING"):
+        check_perms(d, is_dir=True)
+    assert "is world-writable" not in caplog.text
+    os.chmod(d, mode=0o777)
+    with caplog.at_level("WARNING"):
+        check_perms(d, is_dir=True)
+    assert "is world-writable" in caplog.text
 
 
-def test_validate_perms_not_owned(tmp_path, monkeypatch):
+def test_check_perms_not_owned(tmp_path, monkeypatch, caplog):
     # test that validate perms failed if file is not owned by current user (or root)
     # patch stat to return UID=12345
     file = tmp_path / "afile"
@@ -124,8 +135,38 @@ def test_validate_perms_not_owned(tmp_path, monkeypatch):
     from pathlib import Path
     monkeypatch.setattr(Path, "stat", fake_stat)
 
-    with pytest.raises(PermValidationError):
-        validate_perms(file)
+    with caplog.at_level("WARNING"):
+        check_perms(file)
+    assert "not owned by root or current user" in caplog.text
+
+
+@pytest.mark.parametrize("uid,gid,expected_return", [
+    [0, 0, True],
+    [0, os.getgid(), True],
+    [os.getuid(), os.getgid(), True],
+    [0, 12345, False],
+    [12345, 0, False]
+    ])
+def test_has_good_ownership(uid, gid, expected_return):
+    class FakeStatResult(object):
+        def __init__(self, uid, gid):
+            self.st_uid = uid
+            self.st_gid = gid
+    assert _has_good_ownership(FakeStatResult(uid, gid), 1000, 1000) == expected_return
+
+
+@pytest.mark.parametrize("perms,expected_return", [
+    [0o0775, False],
+    [0o0777, True],
+    [0o0007, True],
+    [0o1777, False],
+    ])
+def test_is_world_writable(tmp_path, perms, expected_return):
+    file = tmp_path / "file"
+    file.touch()
+    file.chmod(perms)
+    assert _is_world_writable(file.stat()) == expected_return
+
 
 def test_aqcuire_lock_fail(monkeypatch, tmp_path):
     # test that failure to acquire lock raises an exception


### PR DESCRIPTION
This change prevents USG failing completely when there is a permission issue but instead logs a warning.
This is needed to ensure the drop-in replacement does not break existing workflows.