### PR TITLE
Add support for default tailoring file

### DIFF
--- a/debian/tests/usg-cli-e2e
+++ b/debian/tests/usg-cli-e2e
@@ -58,6 +58,12 @@ sed -e 's/"true"/"false"/g' \
     -e '/file_owner_etc_shadow\|disable_users_coredumps/ s/"false"/"true"/g' \
     -i t1.xml
 
+# test info cmd with tailoring file, without tailoring/profile and with default tailoring file
+test_cmd "usg info -t t1.xml"  0  "Benchmark.*CIS"  ""
+test_cmd "usg info"  2  ""  "a profile or a tailoring file must be provided"
+mkdir -p /etc/usg/ && cp t1.xml /etc/usg/default-tailoring.xml
+test_cmd "usg info"  0  "Using the default tailoring file" ""
+rm /etc/usg/default-tailoring.xml
 
 # Audit with tailoring file, should be 1 pass, 1 fail
 test_cmd "usg audit -t t1.xml"  0  "^Fail:.*1$"  ""

--- a/src/usg/cli.py
+++ b/src/usg/cli.py
@@ -14,9 +14,7 @@ from pathlib import Path
 
 from usg import constants
 from usg.config import load_config, override_config_with_cli_args
-from usg.exceptions import (
-        LockError, ProfileNotFoundError, StateFileError, USGError
-        )
+from usg.exceptions import LockError, ProfileNotFoundError, StateFileError, USGError
 from usg.models import Benchmark, Profile, TailoringFile
 from usg.usg import USG
 from usg.utils import acquire_lock, check_perms
@@ -95,10 +93,10 @@ $ usg generate-fix -t tailoring.xml
 }
 
 CMD_GENERATE_TAILORING_HELP = {
-    "description": """\
+    "description": f"""\
 The generate-tailoring command creates a tailoring file based on the
 provide profile and saves it to the provided output path. To make this
-tailoring file the default save it as /etc/usg/default-tailoring.xml
+tailoring file the default save it as {constants.DEFAULT_TAILORING_PATH}
 
 This command requires a profile upon which the tailoring file will be created.
 All rules present in the base profile will also be present in the tailoring file.
@@ -667,9 +665,17 @@ def parse_args(config_defaults: configparser.ConfigParser) -> argparse.Namespace
             error_exit("You cannot provide both a tailoring file and a profile!", rc=2)
 
         elif not hasattr(args, "profile") and not hasattr(args, "tailoring_file"):
-            sys.stderr.write("Error: a profile or a tailoring file must be provided.\n")
-            cmd_parsers[args.command].print_help()
-            error_exit(rc=2)
+            # Use default tailoring file if it exists
+            default_tailoring = Path(constants.DEFAULT_TAILORING_PATH)
+            if default_tailoring.exists():
+                print(f"Using the default tailoring file at {default_tailoring}")
+                args.tailoring_file = default_tailoring
+            else:
+                sys.stderr.write(
+                    "Error: a profile or a tailoring file must be provided.\n"
+                    )
+                cmd_parsers[args.command].print_help()
+                error_exit(rc=2)
 
     # benchmark_version/product are not compatible with tailoring-file
     if hasattr(args, "tailoring_file") and hasattr(args, "benchmark_version"):

--- a/src/usg/constants.py
+++ b/src/usg/constants.py
@@ -2,6 +2,9 @@
 
 from pathlib import Path
 
+# Default tailoring file location (deprecated)
+DEFAULT_TAILORING_PATH = Path("/etc/usg/default-tailoring.xml")
+
 # CLI configurable options
 CLI_LOG_FILE = "/var/log/usg.log"
 DEFAULT_PRODUCT = "ubuntu2404"


### PR DESCRIPTION
To align with legacy USG, a default tailoring file is loaded if it exists at `/etc/usg/default-tailoring.xml`
and if neither profile nor --tailoring-file arguments are used.