### PR TITLE
Add release timestamp to benchmark metadata and improve build tooling

### DIFF
--- a/src/usg/cli.py
+++ b/src/usg/cli.py
@@ -21,6 +21,7 @@
 
 import argparse
 import configparser
+import datetime
 import json
 import logging
 import os
@@ -256,6 +257,10 @@ def print_info_benchmark(benchmark: Benchmark) -> None:
     else:
         state = "** Deprecated (see information below)**"
 
+    release_date = datetime.datetime.fromtimestamp(
+        benchmark.release_timestamp,
+        datetime.timezone.utc
+        ).isoformat()
     for k, v in [
         ("Benchmark", benchmark.benchmark_type),
         ("Target product", benchmark.product_long),
@@ -264,6 +269,7 @@ def print_info_benchmark(benchmark: Benchmark) -> None:
         ("State", state),
         ("Upgrade candidates", upgrade_path),
         ("Description", benchmark.description.strip()),
+        ("Release date", release_date),
         ("Release notes", benchmark.release_notes_url),
         ("USG benchmark ID", benchmark.id),
         ("Reference", benchmark.reference_url),

--- a/src/usg/models.py
+++ b/src/usg/models.py
@@ -69,6 +69,7 @@ class Benchmark:
     version: str
     description: str
     release_notes_url: str
+    release_timestamp: int
     reference_url: str
     compatible_versions: tuple[str, ...]
     breaking_upgrade_path: tuple[str, ...]
@@ -110,6 +111,7 @@ class Benchmark:
                 version=raw_data["version"],
                 description=raw_data["description"],
                 release_notes_url=raw_data["release_notes_url"],
+                release_timestamp=raw_data["release_timestamp"],
                 reference_url=raw_data["reference_url"],
                 compatible_versions=raw_data["compatible_versions"],
                 breaking_upgrade_path=raw_data["breaking_upgrade_path"],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,7 @@ def dummy_benchmarks(tmp_path_factory):
                 "compatible_versions": [],
                 "breaking_upgrade_path": ["v1.0.1", "v2.0.0"],
                 "is_latest": False,
+                "release_timestamp": 1001,
                 "data_files": {
                     "datastream_gz": {
                         "path": "ubuntu2404_CIS_1/ssg-ubuntu2404-ds.xml.gz",
@@ -90,6 +91,7 @@ def dummy_benchmarks(tmp_path_factory):
                 "compatible_versions": ["v1.0.0.usg1"],
                 "breaking_upgrade_path": ["v2.0.0"],
                 "is_latest": False,
+                "release_timestamp": 1002,
                 "data_files": {
                     "datastream_gz": {
                         "path": "ubuntu2404_CIS_2/ssg-ubuntu2404-ds.xml.gz",
@@ -134,6 +136,7 @@ def dummy_benchmarks(tmp_path_factory):
                 "compatible_versions": [],
                 "breaking_upgrade_path": [],
                 "is_latest": True,
+                "release_timestamp": 1003,
                 "data_files": {
                     "datastream_gz": {
                         "path": "ubuntu2404_CIS_3/ssg-ubuntu2404-ds.xml.gz",
@@ -173,6 +176,7 @@ def dummy_benchmarks(tmp_path_factory):
                 "compatible_versions": [],
                 "breaking_upgrade_path": ["V1R3"],
                 "is_latest": False,
+                "release_timestamp": 1004,
                 "data_files": {
                     "datastream_gz": {
                         "path": "ubuntu2404_STIG_1/ssg-ubuntu2404-ds.xml.gz",
@@ -200,6 +204,7 @@ def dummy_benchmarks(tmp_path_factory):
                 "compatible_versions": ["V1R2"],
                 "breaking_upgrade_path": [],
                 "is_latest": True,
+                "release_timestamp": 1005,
                 "data_files": {
                     "datastream_gz": {
                         "path": "ubuntu2404_STIG_2/ssg-ubuntu2404-ds.xml.gz",

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -99,6 +99,7 @@ def test_usgbenchmark(dummy_benchmarks):
         benchmark.release_notes_url
         == "https://github.com/canonical/ubuntu-security-guide/"
     )
+    assert benchmark.release_timestamp == 1002
     assert (
         benchmark.reference_url == "https://www.cisecurity.org/benchmark/ubuntu_linux/"
     )

--- a/tools/process_benchmarks.py
+++ b/tools/process_benchmarks.py
@@ -432,18 +432,18 @@ def _get_breaking_upgrade_path(
     return breaking_upgrade_path
 
 
-def _build_cac_release(cac_repo_dir: Path, cac_tag: str, cac_product: str) -> int:
-    # Reset CaC repo to tag==cac_tag and build product cac_product
-    # Return timestamp of commit used to build the product
+def _build_cac_release(cac_repo_dir: Path, commit: str, cac_product: str) -> int:
+    # Reset CaC repo to commit and build product cac_product
+    # Return timestamp of commit
     # Raises BenchmarkProcessingError on failure to build
 
-    logger.debug("Building repo {cac_repo_dir}, tag {cac_tag}, product {cac_product}")
+    logger.debug("Building repo {cac_repo_dir}, commit {commit}, product {cac_product}")
 
-    # cleanup repo and checkout tag
+    # cleanup repo and checkout commit
     for cmd in (
         ["/usr/bin/git", "reset", "--hard"],
         ["/usr/bin/git", "clean", "-fxd"],
-        ["/usr/bin/git", "checkout", cac_tag],
+        ["/usr/bin/git", "checkout", commit],
     ):
         logger.debug(f"Calling cmd: {cmd}")
         try:
@@ -459,7 +459,7 @@ def _build_cac_release(cac_repo_dir: Path, cac_tag: str, cac_product: str) -> in
         except subprocess.CalledProcessError as e:
             logger.error(p.stderr)
             raise BenchmarkProcessingError(
-                f"Failed to checkout tag {cac_tag} in repo {cac_repo_dir}: {e}"
+                f"Failed to checkout commit {commit} in repo {cac_repo_dir}: {e}"
                 ) from e
 
 
@@ -476,7 +476,7 @@ def _build_cac_release(cac_repo_dir: Path, cac_tag: str, cac_product: str) -> in
         commit_timestamp = int(out.strip())
     except (subprocess.CalledProcessError, ValueError) as e:
         raise BenchmarkProcessingError(
-            f"Failed to get timestamp for tag {cac_tag}: {e}"
+            f"Failed to get timestamp for commit {commit}: {e}"
         ) from e
 
     logger.debug(f"Commit timestamp: {commit_timestamp}")
@@ -503,7 +503,7 @@ def _build_cac_release(cac_repo_dir: Path, cac_tag: str, cac_product: str) -> in
 
     logger.debug(f"STDOUT: {p.stdout}")
     logger.debug(f"STDERR: {p.stderr}")
-    logger.debug("Successfully built CaC release {cac_tag}")
+    logger.debug("Successfully built CaC release")
     return commit_timestamp
 
 
@@ -615,7 +615,7 @@ def _build_active_releases(
                     )
                 release_timestamp = _build_cac_release(
                     tmp_build_dir,
-                    cac_tag,
+                    release["cac_commit"],
                     b_data["product"]
                 )
                 logger.info("Successfully built CaC content.")

--- a/tools/tests/data/ubuntu2204/expected/benchmarks/benchmarks.json
+++ b/tools/tests/data/ubuntu2204/expected/benchmarks/benchmarks.json
@@ -19,6 +19,7 @@
       "compatible_versions": [],
       "breaking_upgrade_path": [],
       "is_latest": true,
+      "release_timestamp": 1,
       "data_files": {
         "datastream_gz": {
           "path": "ubuntu2204_CIS_1/ssg-ubuntu2204-ds.xml.gz",

--- a/tools/tests/data/ubuntu2404/expected/benchmarks/benchmarks.json
+++ b/tools/tests/data/ubuntu2404/expected/benchmarks/benchmarks.json
@@ -22,6 +22,7 @@
         "v2.0.0"
       ],
       "is_latest": false,
+      "release_timestamp": 1,
       "data_files": {
         "datastream_gz": {
           "path": "ubuntu2404_CIS_1/ssg-ubuntu2404-ds.xml.gz",
@@ -70,6 +71,7 @@
         "v2.0.0"
       ],
       "is_latest": false,
+      "release_timestamp": 2,
       "data_files": {
         "datastream_gz": {
           "path": "ubuntu2404_CIS_2/ssg-ubuntu2404-ds.xml.gz",
@@ -114,6 +116,7 @@
       "compatible_versions": [],
       "breaking_upgrade_path": [],
       "is_latest": true,
+      "release_timestamp": 3,
       "data_files": {
         "datastream_gz": {
           "path": "ubuntu2404_CIS_3/ssg-ubuntu2404-ds.xml.gz",
@@ -159,6 +162,7 @@
         "V1R3"
       ],
       "is_latest": false,
+      "release_timestamp": 4,
       "data_files": {
         "datastream_gz": {
           "path": "ubuntu2404_STIG_1/ssg-ubuntu2404-ds.xml.gz",
@@ -192,6 +196,7 @@
       ],
       "breaking_upgrade_path": [],
       "is_latest": true,
+      "release_timestamp": 5,
       "data_files": {
         "datastream_gz": {
           "path": "ubuntu2404_STIG_2/ssg-ubuntu2404-ds.xml.gz",


### PR DESCRIPTION
Few small changes:
- Add `release_timestamp` field to benchmark metadata and `usg info` (corresponds to the timestamp of the CaC commit which was used to build the datastream)
- Switch from tags to commits when building CaC content
- Add missing build options and improve logging
