### PR TITLE
Autodetect default product and remove option from config

### DIFF
--- a/conf/usg.conf
+++ b/conf/usg.conf
@@ -1,5 +1,4 @@
 [cli]
-product = ubuntu2404
 #log_path = /var/log/usg.log
 #fix_only_failed = false
 

--- a/src/usg/cli.py
+++ b/src/usg/cli.py
@@ -219,7 +219,7 @@ def command_info(usg: USG, args: argparse.Namespace) -> None:
                 args.profile, args.product, benchmark_version
             )
         except ProfileNotFoundError as e:
-            error_exit(f"{e}\nSee `usg list` for list of available profiles.", rc=1)
+            error_exit(f"{e}\nSee `usg list --all` for list of available profiles.", rc=1)
     print_info_profile(usg_profile)
     print_info_benchmark(usg.get_benchmark_by_id(usg_profile.benchmark_id))
     logger.debug("Finished command_info")
@@ -464,7 +464,7 @@ def get_usg_profile_from_args(usg: USG, args: argparse.Namespace) -> Profile:
                 benchmark_version
                 )
         except ProfileNotFoundError as e:
-            error_exit(f"{e}\nSee `usg list` for list of available profiles.", rc=1)
+            error_exit(f"{e}\nSee `usg list --all` for list of available profiles.", rc=1)
 
         # update the benchmark version in the state file
         benchmark = usg.get_benchmark_by_id(profile.benchmark_id)
@@ -574,12 +574,10 @@ def parse_args(config_defaults: configparser.ConfigParser) -> argparse.Namespace
             )
 
         if command in ["info", "audit", "fix", "generate-fix", "generate-tailoring"]:
-            # Not useful until multiple products exist.
-            # Avoid polluting the CLI and hardcode it to the config value for now.
+            # Product argument is not needed until multiple products exist.
+            # Avoid polluting the CLI and hardcode it to the default for now.
             cmd_parser.set_defaults(
-                product=config_defaults.get(
-                    "cli", "product", fallback=constants.DEFAULT_PRODUCT
-                )
+                product=constants.DEFAULT_PRODUCT
             )
             cmd_parser.add_argument(
                 "-b",

--- a/src/usg/config.py
+++ b/src/usg/config.py
@@ -29,7 +29,6 @@ logger = logging.getLogger(__name__)
 DEFAULT_CONFIG = {
     "cli": {
         "log_file": constants.CLI_LOG_FILE,
-        "product": constants.DEFAULT_PRODUCT,
         "fix_only_failed": constants.DEFAULT_FIX_ONLY_FAILED,
     },
     "openscap_backend": {

--- a/src/usg/constants.py
+++ b/src/usg/constants.py
@@ -19,12 +19,13 @@
 
 from pathlib import Path
 
-# Default tailoring file location (deprecated)
+from usg.version import __version__
+
+# Default tailoring file location
 DEFAULT_TAILORING_PATH = Path("/etc/usg/default-tailoring.xml")
 
 # CLI configurable options
 CLI_LOG_FILE = "/var/log/usg.log"
-DEFAULT_PRODUCT = "ubuntu2404"
 DEFAULT_FIX_ONLY_FAILED = False
 
 # Openscap backend options
@@ -46,3 +47,6 @@ STATE_DIR = Path("/var/lib/usg")
 CLI_STATE_FILE = STATE_DIR / ".state.json"
 OPENSCAP_BIN_PATH = Path("/usr/bin/oscap")
 LOCK_PATH = Path("/run/lock/usg.lock")
+
+# Set default benchmark product based on USG version (e.g. ubuntu2404)
+DEFAULT_PRODUCT = f"ubuntu{__version__[:2]}04"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -38,6 +38,7 @@ def patch_usg_and_cli(tmp_path_factory, dummy_benchmarks):
     # patch the usg module:
     # - set benchmarks to dummy benchmarks fixture
     # - set state_dir to a tmp path
+    # - set default product to match dummy_benchmarks
     # - set check_perms, verify_integrity, and acquire_lock to no-ops
     # - patch USG with a dummy USG class overriding audit, generate_fix, fix
     # - change working directory to a tmp dir and create tailoring file in it
@@ -55,6 +56,7 @@ def patch_usg_and_cli(tmp_path_factory, dummy_benchmarks):
     mp.setattr(constants, "CONFIG_PATH", dummy_cfg)
     mp.setattr(constants, "LOCK_PATH", tmp_state_dir / "usg.lock")
     mp.setattr(constants, "CLI_LOG_FILE", "usg.log")
+    mp.setattr(constants, "DEFAULT_PRODUCT", "ubuntu2404")
 
     mp.setattr(utils, "check_perms", lambda *a, **k: None)
     mp.setattr(utils, "verify_integrity", lambda *a, **k: None)


### PR DESCRIPTION
The default product can be reliably detected based on the usg version (24.04.x -> ubuntu2404).

Setting it in the config file can only lead to misconfiguration.