### PR TITLE
Fix rule sorting in tailoring files

### DIFF
--- a/tools/generate_tailoring_file.py
+++ b/tools/generate_tailoring_file.py
@@ -103,7 +103,7 @@ def generate_tailoring_file(
         control_map[var.control.control_id]["vars"].append(var)
 
     logger.debug("Inserting rules and variables into tailoring file")
-    for control_id in sorted(control_map):
+    for control_id in control_map:
         logger.debug(f"Processing control {control_id}")
         control_rules = control_map[control_id]["rules"]
         control_vars = control_map[control_id]["vars"]

--- a/tools/tests/data/ubuntu2204/expected/benchmarks/benchmarks.json
+++ b/tools/tests/data/ubuntu2204/expected/benchmarks/benchmarks.json
@@ -31,19 +31,19 @@
       "tailoring_files": {
         "cis_level1_server": {
           "path": "ubuntu2204_CIS_1/tailoring/cis_level1_server-tailoring.xml",
-          "sha256": "66aac0cfeaf09a7362798de85b36c9a5e2afc160f03d3f34cfc37b8abd289773"
+          "sha256": "f057cfcf05029f7eda4eccc988a650e9fece6a014fc6cb56a91568dbea32dbb8"
         },
         "cis_level2_server": {
           "path": "ubuntu2204_CIS_1/tailoring/cis_level2_server-tailoring.xml",
-          "sha256": "d4856ced42874bf056e59f05b4082268869066c66721b7c53eb0b9c54bdba6a4"
+          "sha256": "c71cfb7a7c96abc935303c7ed5479c8871ab0cd5aecc74dda340b48bb6b0e382"
         },
         "cis_level1_workstation": {
           "path": "ubuntu2204_CIS_1/tailoring/cis_level1_workstation-tailoring.xml",
-          "sha256": "ca14953871703da8794a96d4e5e7599c9d4d8657aa3d500b7c35b279c46628d3"
+          "sha256": "2141ff47dc8c47a980b60d2528443275860820b842fa51ec4379c4c739137cc4"
         },
         "cis_level2_workstation": {
           "path": "ubuntu2204_CIS_1/tailoring/cis_level2_workstation-tailoring.xml",
-          "sha256": "5e84268aedf20178da92675af568ef65d44bc9a5de3c0059efd6bcd99098f19f"
+          "sha256": "187deba578498e03169703d712e5fd30c74e32722b6470d2001d2299e752b997"
         }
       }
     }

--- a/tools/tests/data/ubuntu2204/expected/benchmarks/ubuntu2204_CIS_1/tailoring/cis_level1_server-tailoring.xml
+++ b/tools/tests/data/ubuntu2204/expected/benchmarks/ubuntu2204_CIS_1/tailoring/cis_level1_server-tailoring.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Tailoring xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_scap-workbench_tailoring_default">
   <benchmark href="/usr/share/usg-benchmarks/ubuntu2204_CIS_1"/>
-  <version time="2025-09-19T09:44:09+00:00">1</version>
+  <version time="2025-10-08T21:08:39+00:00">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level1_server_customized" extends="xccdf_org.ssgproject.content_profile_cis_level1_server">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 22.04 Level 1 Server Benchmark [CUSTOMIZED]</title>
     <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 22.04 LTS Benchmark, v1.0.0, released 08-30-2022.</description>

--- a/tools/tests/data/ubuntu2204/expected/benchmarks/ubuntu2204_CIS_1/tailoring/cis_level1_workstation-tailoring.xml
+++ b/tools/tests/data/ubuntu2204/expected/benchmarks/ubuntu2204_CIS_1/tailoring/cis_level1_workstation-tailoring.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Tailoring xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_scap-workbench_tailoring_default">
   <benchmark href="/usr/share/usg-benchmarks/ubuntu2204_CIS_1"/>
-  <version time="2025-09-19T09:44:09+00:00">1</version>
+  <version time="2025-10-08T21:08:40+00:00">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level1_workstation_customized" extends="xccdf_org.ssgproject.content_profile_cis_level1_workstation">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 22.04 Level 1 Workstation Benchmark [CUSTOMIZED]</title>
     <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 22.04 LTS Benchmark, v1.0.0, released 08-30-2022.</description>

--- a/tools/tests/data/ubuntu2204/expected/benchmarks/ubuntu2204_CIS_1/tailoring/cis_level2_server-tailoring.xml
+++ b/tools/tests/data/ubuntu2204/expected/benchmarks/ubuntu2204_CIS_1/tailoring/cis_level2_server-tailoring.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Tailoring xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_scap-workbench_tailoring_default">
   <benchmark href="/usr/share/usg-benchmarks/ubuntu2204_CIS_1"/>
-  <version time="2025-09-19T09:44:09+00:00">1</version>
+  <version time="2025-10-08T21:08:40+00:00">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level2_server_customized" extends="xccdf_org.ssgproject.content_profile_cis_level2_server">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 22.04 Level 2 Server Benchmark [CUSTOMIZED]</title>
     <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 22.04 LTS Benchmark, v1.0.0, released 08-30-2022.</description>

--- a/tools/tests/data/ubuntu2204/expected/benchmarks/ubuntu2204_CIS_1/tailoring/cis_level2_workstation-tailoring.xml
+++ b/tools/tests/data/ubuntu2204/expected/benchmarks/ubuntu2204_CIS_1/tailoring/cis_level2_workstation-tailoring.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Tailoring xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_scap-workbench_tailoring_default">
   <benchmark href="/usr/share/usg-benchmarks/ubuntu2204_CIS_1"/>
-  <version time="2025-09-19T09:44:09+00:00">1</version>
+  <version time="2025-10-08T21:08:40+00:00">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level2_workstation_customized" extends="xccdf_org.ssgproject.content_profile_cis_level2_workstation">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 22.04 Level 2 Workstation Benchmark [CUSTOMIZED]</title>
     <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 22.04 LTS Benchmark, v1.0.0, released 08-30-2022.</description>

--- a/tools/tests/data/ubuntu2404/expected/benchmarks/benchmarks.json
+++ b/tools/tests/data/ubuntu2404/expected/benchmarks/benchmarks.json
@@ -34,19 +34,19 @@
       "tailoring_files": {
         "cis_level1_server": {
           "path": "ubuntu2404_CIS_1/tailoring/cis_level1_server-tailoring.xml",
-          "sha256": "eab1c25d7565f0d28a51220238ab13e8982eeb4042e912b87caae510534cbeb3"
+          "sha256": "438891148f36607a041ea588fb6a9b3ec91f1900b4722b07ed7e3d4ca3ca2ad9"
         },
         "cis_level2_server": {
           "path": "ubuntu2404_CIS_1/tailoring/cis_level2_server-tailoring.xml",
-          "sha256": "32aa8339f2eee97ce9dbe888b8db9e37f17e36d735d71f6d6f884465a64b1587"
+          "sha256": "3c7d818af152fadfe747393f7875319a8153cfbe12629910bdbbeaff1571192f"
         },
         "cis_level1_workstation": {
           "path": "ubuntu2404_CIS_1/tailoring/cis_level1_workstation-tailoring.xml",
-          "sha256": "0b84590aa66f223e49153b359aed2b57578081db8544c77d30ae5a9a50e13470"
+          "sha256": "7b70b208973db366bdde1c6cc455d06837d3e576521d3795db37adac50015364"
         },
         "cis_level2_workstation": {
           "path": "ubuntu2404_CIS_1/tailoring/cis_level2_workstation-tailoring.xml",
-          "sha256": "ab57fa3bde394f15defbf7d90615b2ac60c699571594cf5e8a823afbc6eb76e2"
+          "sha256": "08efa9a5ae8071cfa6419a7af0a81ae072656ef9073773b05590bdb935ed7a77"
         }
       }
     },
@@ -84,19 +84,19 @@
       "tailoring_files": {
         "cis_level1_server": {
           "path": "ubuntu2404_CIS_2/tailoring/cis_level1_server-tailoring.xml",
-          "sha256": "ac76e9afc81ff3499090b966d4cdbaaa87a46d6b9133032c2ec195384f44d507"
+          "sha256": "6f7822a16d208271b263de944d52044684986f6eb5b5f8285d739d49809af1df"
         },
         "cis_level2_server": {
           "path": "ubuntu2404_CIS_2/tailoring/cis_level2_server-tailoring.xml",
-          "sha256": "e50bcbf1feceb5271d59f5ec66e00f827f7c5eb9ff40201e8a3d63f72ef09172"
+          "sha256": "6639a70b7a46562379dff864d727d5e9e0d35c8f7f83d141dad230e7e1c4873c"
         },
         "cis_level1_workstation": {
           "path": "ubuntu2404_CIS_2/tailoring/cis_level1_workstation-tailoring.xml",
-          "sha256": "0fe3574dbed439d68e5160ee1e681aa4f750e94582647dcad173527602d77c4d"
+          "sha256": "6d7c5a36fd2a6d30b56693092be4407aac88d8fc6aec0e2c4b5defddbac21d2c"
         },
         "cis_level2_workstation": {
           "path": "ubuntu2404_CIS_2/tailoring/cis_level2_workstation-tailoring.xml",
-          "sha256": "48f5b0c969cb3209d97507cd182daedd18b6f0dfd61bf674e32dc53f3e498d9c"
+          "sha256": "adf6e1ee2a6b9de9dd0d0a2465445bf1d5815068cfa5092aaf1c37afc0e5ae7d"
         }
       }
     },
@@ -129,11 +129,11 @@
       "tailoring_files": {
         "cis_level1_server": {
           "path": "ubuntu2404_CIS_3/tailoring/cis_level1_server-tailoring.xml",
-          "sha256": "19782c89163a756b372820b7f852bc23074a4578c0526df7a341d3c248e2300d"
+          "sha256": "95e9f13f84d5b468666c278a5220cfa0a86bfb988444514f193a0861de8a1f62"
         },
         "cis_level2_server": {
           "path": "ubuntu2404_CIS_3/tailoring/cis_level2_server-tailoring.xml",
-          "sha256": "d152d7673f43f3c6dee19d5e29cdc393aa352329d474d76af58c06e26d6ac861"
+          "sha256": "9a6953ecc64536c71c45a5745267cb4b343058aa6094d54a8760a0e1b717f364"
         },
         "cis_level1_workstation": {
           "path": "ubuntu2404_CIS_3/tailoring/cis_level1_workstation-tailoring.xml",
@@ -172,7 +172,7 @@
       "tailoring_files": {
         "stig": {
           "path": "ubuntu2404_STIG_1/tailoring/stig-tailoring.xml",
-          "sha256": "7f9d44a8e8765484e21f9fc800593b0d427f83d37674a443be5fb3e0e33e6531"
+          "sha256": "3d29260a26fb1a5b5913b57ecfab59d9c7c76cf5118d2764c623386358f3d210"
         }
       }
     },
@@ -207,7 +207,7 @@
       "tailoring_files": {
         "stig": {
           "path": "ubuntu2404_STIG_2/tailoring/stig-tailoring.xml",
-          "sha256": "cc996240d5c16263a647a431ac8db0f5179cea8d93eb092e32fb3cbf2139ba38"
+          "sha256": "1c4ec05d39b0fd12f0dada508c978f1e1fa5a9c5bf350d18ecaaad73f8928bd9"
         }
       }
     }

--- a/tools/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_1/tailoring/cis_level1_server-tailoring.xml
+++ b/tools/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_1/tailoring/cis_level1_server-tailoring.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Tailoring xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_scap-workbench_tailoring_default">
   <benchmark href="/usr/share/usg-benchmarks/ubuntu2404_CIS_1"/>
-  <version time="2025-09-05T13:35:48+00:00">1</version>
+  <version time="2025-10-08T21:08:49+00:00">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level1_server_customized" extends="xccdf_org.ssgproject.content_profile_cis_level1_server">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 24.04 Level 1 Server Benchmark [CUSTOMIZED]</title>
     <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 24.04 LTS Benchmark, v1.0.0, released 08-26-2024.</description>
@@ -104,8 +104,6 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_issue_net" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_issue_net" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_issue_net" selected="true"/>
-    <!--1.7.10: Ensure XDMCP is not enabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_gnome_gdm_disable_xdmcp" selected="true"/>
     <!--1.7.2: Ensure GDM login banner is configured (Automated)-->
     <set-value idref="xccdf_org.ssgproject.content_value_login_banner_text">^Authorized[\s\n]+users[\s\n]+only\.[\s\n]+All[\s\n]+activity[\s\n]+may[\s\n]+be[\s\n]+monitored[\s\n]+and[\s\n]+reported\.$</set-value>
     <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_banner_enabled" selected="true"/>
@@ -123,9 +121,36 @@
     <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_disable_automount_open" selected="true"/>
     <!--1.7.8: Ensure GDM autorun-never is enabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_disable_autorun" selected="true"/>
+    <!--1.7.10: Ensure XDMCP is not enabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_gnome_gdm_disable_xdmcp" selected="true"/>
     <!--2.1.1: Ensure autofs services are not in use (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_service_autofs_disabled" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_package_autofs_removed" selected="true"/>
+    <!--2.1.2: Ensure avahi daemon services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_avahi_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_avahi-daemon_disabled" selected="true"/>
+    <!--2.1.3: Ensure dhcp server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_dhcp_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd_disabled" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd6_disabled" selected="true"/>
+    <!--2.1.4: Ensure dns server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_bind_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_named_disabled" selected="true"/>
+    <!--2.1.5: Ensure dnsmasq services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_dnsmasq_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dnsmasq_disabled" selected="true"/>
+    <!--2.1.6: Ensure ftp server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_vsftpd_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_vsftpd_disabled" selected="true"/>
+    <!--2.1.7: Ensure ldap server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_openldap-servers_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_slapd_disabled" selected="true"/>
+    <!--2.1.8: Ensure message access server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_dovecot_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dovecot_disabled" selected="true"/>
+    <!--2.1.9: Ensure network file system services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_nfs-kernel-server_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_nfs_disabled" selected="true"/>
     <!--2.1.10: Ensure nis server services are not in use (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_ypserv_removed" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_service_ypserv_disabled" selected="true"/>
@@ -158,35 +183,10 @@
     <!--2.1.19: Ensure xinetd services are not in use (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_xinetd_removed" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_service_xinetd_disabled" selected="true"/>
-    <!--2.1.2: Ensure avahi daemon services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_avahi_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_avahi-daemon_disabled" selected="true"/>
     <!--2.1.21: Ensure mail transfer agent is configured for local-only mode (Automated)-->
     <set-value idref="xccdf_org.ssgproject.content_value_var_postfix_inet_interfaces">loopback-only</set-value>
     <select idref="xccdf_org.ssgproject.content_rule_has_nonlocal_mta" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_postfix_network_listening_disabled" selected="true"/>
-    <!--2.1.3: Ensure dhcp server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_dhcp_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd_disabled" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd6_disabled" selected="true"/>
-    <!--2.1.4: Ensure dns server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_bind_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_named_disabled" selected="true"/>
-    <!--2.1.5: Ensure dnsmasq services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_dnsmasq_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dnsmasq_disabled" selected="true"/>
-    <!--2.1.6: Ensure ftp server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_vsftpd_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_vsftpd_disabled" selected="true"/>
-    <!--2.1.7: Ensure ldap server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_openldap-servers_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_slapd_disabled" selected="true"/>
-    <!--2.1.8: Ensure message access server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_dovecot_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dovecot_disabled" selected="true"/>
-    <!--2.1.9: Ensure network file system services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_nfs-kernel-server_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_nfs_disabled" selected="true"/>
     <!--2.2.1: Ensure NIS Client is not installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_nis_removed" selected="true"/>
     <!--2.2.2: Ensure rsh client is not installed (Automated)-->
@@ -266,11 +266,6 @@
     <!--3.3.1: Ensure ip forwarding is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_forwarding" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_ip_forward" selected="true"/>
-    <!--3.3.10: Ensure tcp syn cookies is enabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_tcp_syncookies" selected="true"/>
-    <!--3.3.11: Ensure ipv6 router advertisements are not accepted (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_accept_ra" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_default_accept_ra" selected="true"/>
     <!--3.3.2: Ensure packet redirect sending is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_send_redirects" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_send_redirects" selected="true"/>
@@ -297,6 +292,11 @@
     <!--3.3.9: Ensure suspicious packets are logged (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_log_martians" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_log_martians" selected="true"/>
+    <!--3.3.10: Ensure tcp syn cookies is enabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_tcp_syncookies" selected="true"/>
+    <!--3.3.11: Ensure ipv6 router advertisements are not accepted (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_accept_ra" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_default_accept_ra" selected="true"/>
     <!--4.1.1: Ensure a single firewall configuration utility is in use (Automated)-->
     <set-value idref="xccdf_org.ssgproject.content_value_var_network_filtering_service">nftables</set-value>
     <select idref="xccdf_org.ssgproject.content_rule_firewall_single_service_active" selected="true"/>
@@ -315,9 +315,6 @@
     <select idref="xccdf_org.ssgproject.content_rule_set_ufw_default_rule" selected="true"/>
     <!--4.3.1: Ensure nftables is installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_nftables_installed" selected="true"/>
-    <!--4.3.10: Ensure nftables rules are permanent (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_nftables_master_config_file">/etc/nftables.conf</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_nftables_rules_permanent" selected="true"/>
     <!--4.3.2: Ensure ufw is uninstalled or disabled with nftables (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_ufw_removed" selected="true"/>
     <!--4.3.4: Ensure a nftables table exists (Automated)-->
@@ -337,6 +334,9 @@
     <select idref="xccdf_org.ssgproject.content_rule_nftables_ensure_default_deny_policy" selected="true"/>
     <!--4.3.9: Ensure nftables service is enabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_service_nftables_enabled" selected="true"/>
+    <!--4.3.10: Ensure nftables rules are permanent (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_nftables_master_config_file">/etc/nftables.conf</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_nftables_rules_permanent" selected="true"/>
     <!--4.4.1.1: Ensure iptables packages are installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_iptables-persistent_installed" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_package_iptables_installed" selected="true"/>
@@ -358,6 +358,21 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_sshd_config" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_sshd_config" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_config" selected="true"/>
+    <!--5.1.2: Ensure permissions on SSH private host key files are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_private_key" selected="true"/>
+    <!--5.1.3: Ensure permissions on SSH public host key files are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_pub_key" selected="true"/>
+    <!--5.1.4: Ensure sshd access is configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_limit_user_access" selected="true"/>
+    <!--5.1.5: Ensure sshd Banner is configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_enable_warning_banner_net" selected="true"/>
+    <!--5.1.6: Ensure sshd Ciphers are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_use_strong_ciphers" selected="true"/>
+    <!--5.1.7: Ensure sshd ClientAliveInterval and ClientAliveCountMax are configured (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_sshd_idle_timeout_value">300</set-value>
+    <set-value idref="xccdf_org.ssgproject.content_value_var_sshd_set_keepalive">3</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_idle_timeout" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_keepalive" selected="true"/>
     <!--5.1.10: Ensure sshd HostbasedAuthentication is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_disable_host_auth" selected="true"/>
     <!--5.1.11: Ensure sshd IgnoreRhosts is enabled (Automated)-->
@@ -384,27 +399,12 @@
     <select idref="xccdf_org.ssgproject.content_rule_sshd_set_maxstartups" selected="true"/>
     <!--5.1.19: Ensure sshd PermitEmptyPasswords is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_empty_passwords" selected="true"/>
-    <!--5.1.2: Ensure permissions on SSH private host key files are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_private_key" selected="true"/>
     <!--5.1.20: Ensure sshd PermitRootLogin is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_root_login" selected="true"/>
     <!--5.1.21: Ensure sshd PermitUserEnvironment is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_do_not_permit_user_env" selected="true"/>
     <!--5.1.22: Ensure sshd UsePAM is enabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_enable_pam" selected="true"/>
-    <!--5.1.3: Ensure permissions on SSH public host key files are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_pub_key" selected="true"/>
-    <!--5.1.4: Ensure sshd access is configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_limit_user_access" selected="true"/>
-    <!--5.1.5: Ensure sshd Banner is configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_enable_warning_banner_net" selected="true"/>
-    <!--5.1.6: Ensure sshd Ciphers are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_use_strong_ciphers" selected="true"/>
-    <!--5.1.7: Ensure sshd ClientAliveInterval and ClientAliveCountMax are configured (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_sshd_idle_timeout_value">300</set-value>
-    <set-value idref="xccdf_org.ssgproject.content_value_var_sshd_set_keepalive">3</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_idle_timeout" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_keepalive" selected="true"/>
     <!--5.2.1: Ensure sudo is installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_sudo_installed" selected="true"/>
     <!--5.2.2: Ensure sudo commands use pty (Automated)-->
@@ -614,18 +614,6 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_passwd" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_passwd" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_passwd" selected="true"/>
-    <!--7.1.10: Ensure permissions on /etc/security/opasswd are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd_old" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd_old" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd_old" selected="true"/>
-    <!--7.1.11: Ensure world writable files and directories are secured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_unauthorized_world_writable" selected="true"/>
-    <!--7.1.12: Ensure no files or directories without an owner and a group exist (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_no_files_unowned_by_user" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_ungroupowned" selected="true"/>
     <!--7.1.2: Ensure permissions on /etc/passwd- are configured (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_backup_etc_passwd" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_backup_etc_passwd" selected="true"/>
@@ -658,17 +646,20 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_shells" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_shells" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_shells" selected="true"/>
+    <!--7.1.10: Ensure permissions on /etc/security/opasswd are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd_old" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd_old" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd_old" selected="true"/>
+    <!--7.1.11: Ensure world writable files and directories are secured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_unauthorized_world_writable" selected="true"/>
+    <!--7.1.12: Ensure no files or directories without an owner and a group exist (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_no_files_unowned_by_user" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_ungroupowned" selected="true"/>
     <!--7.2.1: Ensure accounts in /etc/passwd use shadowed passwords (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_accounts_password_all_shadowed" selected="true"/>
-    <!--7.2.10: Ensure local interactive user dot files access is configured (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_user_initialization_files_regex">^\.[\w\- ]+$</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_no_rsh_trust_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_no_forward_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_no_netrc_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_user_ownership" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_group_ownership" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_init_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_bash_history" selected="true"/>
     <!--7.2.2: Ensure /etc/shadow password fields are not empty (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_no_empty_passwords_etc_shadow" selected="true"/>
     <!--7.2.3: Ensure all groups in /etc/passwd exist in /etc/group (Automated)-->
@@ -688,5 +679,14 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_groupownership_home_directories" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_ownership_home_directories" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_home_directories" selected="true"/>
+    <!--7.2.10: Ensure local interactive user dot files access is configured (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_user_initialization_files_regex">^\.[\w\- ]+$</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_no_rsh_trust_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_no_forward_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_no_netrc_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_user_ownership" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_group_ownership" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_init_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_bash_history" selected="true"/>
   </Profile>
 </Tailoring>

--- a/tools/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_1/tailoring/cis_level1_workstation-tailoring.xml
+++ b/tools/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_1/tailoring/cis_level1_workstation-tailoring.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Tailoring xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_scap-workbench_tailoring_default">
   <benchmark href="/usr/share/usg-benchmarks/ubuntu2404_CIS_1"/>
-  <version time="2025-09-05T13:35:49+00:00">1</version>
+  <version time="2025-10-08T21:08:50+00:00">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level1_workstation_customized" extends="xccdf_org.ssgproject.content_profile_cis_level1_workstation">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 24.04 Level 1 Workstation Benchmark [CUSTOMIZED]</title>
     <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 24.04 LTS Benchmark, v1.0.0, released 08-26-2024.</description>
@@ -102,8 +102,6 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_issue_net" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_issue_net" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_issue_net" selected="true"/>
-    <!--1.7.10: Ensure XDMCP is not enabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_gnome_gdm_disable_xdmcp" selected="true"/>
     <!--1.7.2: Ensure GDM login banner is configured (Automated)-->
     <set-value idref="xccdf_org.ssgproject.content_value_login_banner_text">^Authorized[\s\n]+users[\s\n]+only\.[\s\n]+All[\s\n]+activity[\s\n]+may[\s\n]+be[\s\n]+monitored[\s\n]+and[\s\n]+reported\.$</set-value>
     <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_banner_enabled" selected="true"/>
@@ -118,6 +116,30 @@
     <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_screensaver_lock_delay" selected="true"/>
     <!--1.7.8: Ensure GDM autorun-never is enabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_disable_autorun" selected="true"/>
+    <!--1.7.10: Ensure XDMCP is not enabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_gnome_gdm_disable_xdmcp" selected="true"/>
+    <!--2.1.3: Ensure dhcp server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_dhcp_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd_disabled" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd6_disabled" selected="true"/>
+    <!--2.1.4: Ensure dns server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_bind_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_named_disabled" selected="true"/>
+    <!--2.1.5: Ensure dnsmasq services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_dnsmasq_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dnsmasq_disabled" selected="true"/>
+    <!--2.1.6: Ensure ftp server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_vsftpd_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_vsftpd_disabled" selected="true"/>
+    <!--2.1.7: Ensure ldap server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_openldap-servers_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_slapd_disabled" selected="true"/>
+    <!--2.1.8: Ensure message access server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_dovecot_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dovecot_disabled" selected="true"/>
+    <!--2.1.9: Ensure network file system services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_nfs-kernel-server_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_nfs_disabled" selected="true"/>
     <!--2.1.10: Ensure nis server services are not in use (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_ypserv_removed" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_service_ypserv_disabled" selected="true"/>
@@ -151,28 +173,6 @@
     <set-value idref="xccdf_org.ssgproject.content_value_var_postfix_inet_interfaces">loopback-only</set-value>
     <select idref="xccdf_org.ssgproject.content_rule_has_nonlocal_mta" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_postfix_network_listening_disabled" selected="true"/>
-    <!--2.1.3: Ensure dhcp server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_dhcp_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd_disabled" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd6_disabled" selected="true"/>
-    <!--2.1.4: Ensure dns server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_bind_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_named_disabled" selected="true"/>
-    <!--2.1.5: Ensure dnsmasq services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_dnsmasq_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dnsmasq_disabled" selected="true"/>
-    <!--2.1.6: Ensure ftp server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_vsftpd_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_vsftpd_disabled" selected="true"/>
-    <!--2.1.7: Ensure ldap server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_openldap-servers_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_slapd_disabled" selected="true"/>
-    <!--2.1.8: Ensure message access server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_dovecot_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dovecot_disabled" selected="true"/>
-    <!--2.1.9: Ensure network file system services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_nfs-kernel-server_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_nfs_disabled" selected="true"/>
     <!--2.2.1: Ensure NIS Client is not installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_nis_removed" selected="true"/>
     <!--2.2.2: Ensure rsh client is not installed (Automated)-->
@@ -248,11 +248,6 @@
     <!--3.3.1: Ensure ip forwarding is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_forwarding" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_ip_forward" selected="true"/>
-    <!--3.3.10: Ensure tcp syn cookies is enabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_tcp_syncookies" selected="true"/>
-    <!--3.3.11: Ensure ipv6 router advertisements are not accepted (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_accept_ra" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_default_accept_ra" selected="true"/>
     <!--3.3.2: Ensure packet redirect sending is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_send_redirects" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_send_redirects" selected="true"/>
@@ -279,6 +274,11 @@
     <!--3.3.9: Ensure suspicious packets are logged (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_log_martians" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_log_martians" selected="true"/>
+    <!--3.3.10: Ensure tcp syn cookies is enabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_tcp_syncookies" selected="true"/>
+    <!--3.3.11: Ensure ipv6 router advertisements are not accepted (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_accept_ra" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_default_accept_ra" selected="true"/>
     <!--4.1.1: Ensure a single firewall configuration utility is in use (Automated)-->
     <set-value idref="xccdf_org.ssgproject.content_value_var_network_filtering_service">nftables</set-value>
     <select idref="xccdf_org.ssgproject.content_rule_firewall_single_service_active" selected="true"/>
@@ -297,9 +297,6 @@
     <select idref="xccdf_org.ssgproject.content_rule_set_ufw_default_rule" selected="true"/>
     <!--4.3.1: Ensure nftables is installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_nftables_installed" selected="true"/>
-    <!--4.3.10: Ensure nftables rules are permanent (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_nftables_master_config_file">/etc/nftables.conf</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_nftables_rules_permanent" selected="true"/>
     <!--4.3.2: Ensure ufw is uninstalled or disabled with nftables (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_ufw_removed" selected="true"/>
     <!--4.3.4: Ensure a nftables table exists (Automated)-->
@@ -319,6 +316,9 @@
     <select idref="xccdf_org.ssgproject.content_rule_nftables_ensure_default_deny_policy" selected="true"/>
     <!--4.3.9: Ensure nftables service is enabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_service_nftables_enabled" selected="true"/>
+    <!--4.3.10: Ensure nftables rules are permanent (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_nftables_master_config_file">/etc/nftables.conf</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_nftables_rules_permanent" selected="true"/>
     <!--4.4.1.1: Ensure iptables packages are installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_iptables-persistent_installed" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_package_iptables_installed" selected="true"/>
@@ -340,6 +340,25 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_sshd_config" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_sshd_config" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_config" selected="true"/>
+    <!--5.1.2: Ensure permissions on SSH private host key files are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_private_key" selected="true"/>
+    <!--5.1.3: Ensure permissions on SSH public host key files are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_pub_key" selected="true"/>
+    <!--5.1.4: Ensure sshd access is configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_limit_user_access" selected="true"/>
+    <!--5.1.5: Ensure sshd Banner is configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_enable_warning_banner_net" selected="true"/>
+    <!--5.1.6: Ensure sshd Ciphers are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_use_strong_ciphers" selected="true"/>
+    <!--5.1.7: Ensure sshd ClientAliveInterval and ClientAliveCountMax are configured (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_sshd_idle_timeout_value">300</set-value>
+    <set-value idref="xccdf_org.ssgproject.content_value_var_sshd_set_keepalive">3</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_idle_timeout" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_keepalive" selected="true"/>
+    <!--5.1.8: Ensure sshd DisableForwarding is enabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_forwarding" selected="true"/>
+    <!--5.1.9: Ensure sshd GSSAPIAuthentication is disabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_gssapi_auth" selected="true"/>
     <!--5.1.10: Ensure sshd HostbasedAuthentication is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_disable_host_auth" selected="true"/>
     <!--5.1.11: Ensure sshd IgnoreRhosts is enabled (Automated)-->
@@ -366,31 +385,12 @@
     <select idref="xccdf_org.ssgproject.content_rule_sshd_set_maxstartups" selected="true"/>
     <!--5.1.19: Ensure sshd PermitEmptyPasswords is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_empty_passwords" selected="true"/>
-    <!--5.1.2: Ensure permissions on SSH private host key files are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_private_key" selected="true"/>
     <!--5.1.20: Ensure sshd PermitRootLogin is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_root_login" selected="true"/>
     <!--5.1.21: Ensure sshd PermitUserEnvironment is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_do_not_permit_user_env" selected="true"/>
     <!--5.1.22: Ensure sshd UsePAM is enabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_enable_pam" selected="true"/>
-    <!--5.1.3: Ensure permissions on SSH public host key files are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_pub_key" selected="true"/>
-    <!--5.1.4: Ensure sshd access is configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_limit_user_access" selected="true"/>
-    <!--5.1.5: Ensure sshd Banner is configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_enable_warning_banner_net" selected="true"/>
-    <!--5.1.6: Ensure sshd Ciphers are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_use_strong_ciphers" selected="true"/>
-    <!--5.1.7: Ensure sshd ClientAliveInterval and ClientAliveCountMax are configured (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_sshd_idle_timeout_value">300</set-value>
-    <set-value idref="xccdf_org.ssgproject.content_value_var_sshd_set_keepalive">3</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_idle_timeout" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_keepalive" selected="true"/>
-    <!--5.1.8: Ensure sshd DisableForwarding is enabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_forwarding" selected="true"/>
-    <!--5.1.9: Ensure sshd GSSAPIAuthentication is disabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_gssapi_auth" selected="true"/>
     <!--5.2.1: Ensure sudo is installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_sudo_installed" selected="true"/>
     <!--5.2.2: Ensure sudo commands use pty (Automated)-->
@@ -600,18 +600,6 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_passwd" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_passwd" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_passwd" selected="true"/>
-    <!--7.1.10: Ensure permissions on /etc/security/opasswd are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd_old" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd_old" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd_old" selected="true"/>
-    <!--7.1.11: Ensure world writable files and directories are secured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_unauthorized_world_writable" selected="true"/>
-    <!--7.1.12: Ensure no files or directories without an owner and a group exist (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_no_files_unowned_by_user" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_ungroupowned" selected="true"/>
     <!--7.1.2: Ensure permissions on /etc/passwd- are configured (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_backup_etc_passwd" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_backup_etc_passwd" selected="true"/>
@@ -644,17 +632,20 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_shells" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_shells" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_shells" selected="true"/>
+    <!--7.1.10: Ensure permissions on /etc/security/opasswd are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd_old" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd_old" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd_old" selected="true"/>
+    <!--7.1.11: Ensure world writable files and directories are secured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_unauthorized_world_writable" selected="true"/>
+    <!--7.1.12: Ensure no files or directories without an owner and a group exist (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_no_files_unowned_by_user" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_ungroupowned" selected="true"/>
     <!--7.2.1: Ensure accounts in /etc/passwd use shadowed passwords (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_accounts_password_all_shadowed" selected="true"/>
-    <!--7.2.10: Ensure local interactive user dot files access is configured (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_user_initialization_files_regex">^\.[\w\- ]+$</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_no_rsh_trust_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_no_forward_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_no_netrc_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_user_ownership" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_group_ownership" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_init_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_bash_history" selected="true"/>
     <!--7.2.2: Ensure /etc/shadow password fields are not empty (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_no_empty_passwords_etc_shadow" selected="true"/>
     <!--7.2.3: Ensure all groups in /etc/passwd exist in /etc/group (Automated)-->
@@ -674,5 +665,14 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_groupownership_home_directories" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_ownership_home_directories" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_home_directories" selected="true"/>
+    <!--7.2.10: Ensure local interactive user dot files access is configured (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_user_initialization_files_regex">^\.[\w\- ]+$</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_no_rsh_trust_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_no_forward_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_no_netrc_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_user_ownership" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_group_ownership" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_init_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_bash_history" selected="true"/>
   </Profile>
 </Tailoring>

--- a/tools/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_1/tailoring/cis_level2_server-tailoring.xml
+++ b/tools/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_1/tailoring/cis_level2_server-tailoring.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Tailoring xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_scap-workbench_tailoring_default">
   <benchmark href="/usr/share/usg-benchmarks/ubuntu2404_CIS_1"/>
-  <version time="2025-09-05T13:35:49+00:00">1</version>
+  <version time="2025-10-08T21:08:50+00:00">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level2_server_customized" extends="xccdf_org.ssgproject.content_profile_cis_level2_server">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 24.04 Level 2 Server Benchmark [CUSTOMIZED]</title>
     <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 24.04 LTS Benchmark, v1.0.0, released 08-26-2024.</description>
@@ -122,8 +122,6 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_issue_net" selected="true"/>
     <!--1.7.1: Ensure GDM is removed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_gdm_removed" selected="true"/>
-    <!--1.7.10: Ensure XDMCP is not enabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_gnome_gdm_disable_xdmcp" selected="true"/>
     <!--1.7.2: Ensure GDM login banner is configured (Automated)-->
     <set-value idref="xccdf_org.ssgproject.content_value_login_banner_text">^Authorized[\s\n]+users[\s\n]+only\.[\s\n]+All[\s\n]+activity[\s\n]+may[\s\n]+be[\s\n]+monitored[\s\n]+and[\s\n]+reported\.$</set-value>
     <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_banner_enabled" selected="true"/>
@@ -141,9 +139,36 @@
     <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_disable_automount_open" selected="true"/>
     <!--1.7.8: Ensure GDM autorun-never is enabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_disable_autorun" selected="true"/>
+    <!--1.7.10: Ensure XDMCP is not enabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_gnome_gdm_disable_xdmcp" selected="true"/>
     <!--2.1.1: Ensure autofs services are not in use (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_service_autofs_disabled" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_package_autofs_removed" selected="true"/>
+    <!--2.1.2: Ensure avahi daemon services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_avahi_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_avahi-daemon_disabled" selected="true"/>
+    <!--2.1.3: Ensure dhcp server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_dhcp_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd_disabled" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd6_disabled" selected="true"/>
+    <!--2.1.4: Ensure dns server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_bind_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_named_disabled" selected="true"/>
+    <!--2.1.5: Ensure dnsmasq services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_dnsmasq_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dnsmasq_disabled" selected="true"/>
+    <!--2.1.6: Ensure ftp server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_vsftpd_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_vsftpd_disabled" selected="true"/>
+    <!--2.1.7: Ensure ldap server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_openldap-servers_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_slapd_disabled" selected="true"/>
+    <!--2.1.8: Ensure message access server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_dovecot_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dovecot_disabled" selected="true"/>
+    <!--2.1.9: Ensure network file system services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_nfs-kernel-server_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_nfs_disabled" selected="true"/>
     <!--2.1.10: Ensure nis server services are not in use (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_ypserv_removed" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_service_ypserv_disabled" selected="true"/>
@@ -176,37 +201,12 @@
     <!--2.1.19: Ensure xinetd services are not in use (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_xinetd_removed" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_service_xinetd_disabled" selected="true"/>
-    <!--2.1.2: Ensure avahi daemon services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_avahi_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_avahi-daemon_disabled" selected="true"/>
     <!--2.1.20: Ensure X window server services are not in use (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_xorg-x11-server-common_removed" selected="true"/>
     <!--2.1.21: Ensure mail transfer agent is configured for local-only mode (Automated)-->
     <set-value idref="xccdf_org.ssgproject.content_value_var_postfix_inet_interfaces">loopback-only</set-value>
     <select idref="xccdf_org.ssgproject.content_rule_has_nonlocal_mta" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_postfix_network_listening_disabled" selected="true"/>
-    <!--2.1.3: Ensure dhcp server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_dhcp_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd_disabled" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd6_disabled" selected="true"/>
-    <!--2.1.4: Ensure dns server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_bind_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_named_disabled" selected="true"/>
-    <!--2.1.5: Ensure dnsmasq services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_dnsmasq_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dnsmasq_disabled" selected="true"/>
-    <!--2.1.6: Ensure ftp server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_vsftpd_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_vsftpd_disabled" selected="true"/>
-    <!--2.1.7: Ensure ldap server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_openldap-servers_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_slapd_disabled" selected="true"/>
-    <!--2.1.8: Ensure message access server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_dovecot_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dovecot_disabled" selected="true"/>
-    <!--2.1.9: Ensure network file system services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_nfs-kernel-server_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_nfs_disabled" selected="true"/>
     <!--2.2.1: Ensure NIS Client is not installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_nis_removed" selected="true"/>
     <!--2.2.2: Ensure rsh client is not installed (Automated)-->
@@ -294,11 +294,6 @@
     <!--3.3.1: Ensure ip forwarding is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_forwarding" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_ip_forward" selected="true"/>
-    <!--3.3.10: Ensure tcp syn cookies is enabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_tcp_syncookies" selected="true"/>
-    <!--3.3.11: Ensure ipv6 router advertisements are not accepted (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_accept_ra" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_default_accept_ra" selected="true"/>
     <!--3.3.2: Ensure packet redirect sending is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_send_redirects" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_send_redirects" selected="true"/>
@@ -325,6 +320,11 @@
     <!--3.3.9: Ensure suspicious packets are logged (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_log_martians" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_log_martians" selected="true"/>
+    <!--3.3.10: Ensure tcp syn cookies is enabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_tcp_syncookies" selected="true"/>
+    <!--3.3.11: Ensure ipv6 router advertisements are not accepted (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_accept_ra" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_default_accept_ra" selected="true"/>
     <!--4.1.1: Ensure a single firewall configuration utility is in use (Automated)-->
     <set-value idref="xccdf_org.ssgproject.content_value_var_network_filtering_service">nftables</set-value>
     <select idref="xccdf_org.ssgproject.content_rule_firewall_single_service_active" selected="true"/>
@@ -343,9 +343,6 @@
     <select idref="xccdf_org.ssgproject.content_rule_set_ufw_default_rule" selected="true"/>
     <!--4.3.1: Ensure nftables is installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_nftables_installed" selected="true"/>
-    <!--4.3.10: Ensure nftables rules are permanent (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_nftables_master_config_file">/etc/nftables.conf</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_nftables_rules_permanent" selected="true"/>
     <!--4.3.2: Ensure ufw is uninstalled or disabled with nftables (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_ufw_removed" selected="true"/>
     <!--4.3.4: Ensure a nftables table exists (Automated)-->
@@ -365,6 +362,9 @@
     <select idref="xccdf_org.ssgproject.content_rule_nftables_ensure_default_deny_policy" selected="true"/>
     <!--4.3.9: Ensure nftables service is enabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_service_nftables_enabled" selected="true"/>
+    <!--4.3.10: Ensure nftables rules are permanent (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_nftables_master_config_file">/etc/nftables.conf</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_nftables_rules_permanent" selected="true"/>
     <!--4.4.1.1: Ensure iptables packages are installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_iptables-persistent_installed" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_package_iptables_installed" selected="true"/>
@@ -386,6 +386,25 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_sshd_config" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_sshd_config" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_config" selected="true"/>
+    <!--5.1.2: Ensure permissions on SSH private host key files are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_private_key" selected="true"/>
+    <!--5.1.3: Ensure permissions on SSH public host key files are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_pub_key" selected="true"/>
+    <!--5.1.4: Ensure sshd access is configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_limit_user_access" selected="true"/>
+    <!--5.1.5: Ensure sshd Banner is configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_enable_warning_banner_net" selected="true"/>
+    <!--5.1.6: Ensure sshd Ciphers are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_use_strong_ciphers" selected="true"/>
+    <!--5.1.7: Ensure sshd ClientAliveInterval and ClientAliveCountMax are configured (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_sshd_idle_timeout_value">300</set-value>
+    <set-value idref="xccdf_org.ssgproject.content_value_var_sshd_set_keepalive">3</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_idle_timeout" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_keepalive" selected="true"/>
+    <!--5.1.8: Ensure sshd DisableForwarding is enabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_forwarding" selected="true"/>
+    <!--5.1.9: Ensure sshd GSSAPIAuthentication is disabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_gssapi_auth" selected="true"/>
     <!--5.1.10: Ensure sshd HostbasedAuthentication is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_disable_host_auth" selected="true"/>
     <!--5.1.11: Ensure sshd IgnoreRhosts is enabled (Automated)-->
@@ -412,31 +431,12 @@
     <select idref="xccdf_org.ssgproject.content_rule_sshd_set_maxstartups" selected="true"/>
     <!--5.1.19: Ensure sshd PermitEmptyPasswords is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_empty_passwords" selected="true"/>
-    <!--5.1.2: Ensure permissions on SSH private host key files are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_private_key" selected="true"/>
     <!--5.1.20: Ensure sshd PermitRootLogin is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_root_login" selected="true"/>
     <!--5.1.21: Ensure sshd PermitUserEnvironment is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_do_not_permit_user_env" selected="true"/>
     <!--5.1.22: Ensure sshd UsePAM is enabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_enable_pam" selected="true"/>
-    <!--5.1.3: Ensure permissions on SSH public host key files are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_pub_key" selected="true"/>
-    <!--5.1.4: Ensure sshd access is configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_limit_user_access" selected="true"/>
-    <!--5.1.5: Ensure sshd Banner is configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_enable_warning_banner_net" selected="true"/>
-    <!--5.1.6: Ensure sshd Ciphers are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_use_strong_ciphers" selected="true"/>
-    <!--5.1.7: Ensure sshd ClientAliveInterval and ClientAliveCountMax are configured (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_sshd_idle_timeout_value">300</set-value>
-    <set-value idref="xccdf_org.ssgproject.content_value_var_sshd_set_keepalive">3</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_idle_timeout" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_keepalive" selected="true"/>
-    <!--5.1.8: Ensure sshd DisableForwarding is enabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_forwarding" selected="true"/>
-    <!--5.1.9: Ensure sshd GSSAPIAuthentication is disabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_gssapi_auth" selected="true"/>
     <!--5.2.1: Ensure sudo is installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_sudo_installed" selected="true"/>
     <!--5.2.2: Ensure sudo commands use pty (Automated)-->
@@ -678,41 +678,8 @@
     <select idref="xccdf_org.ssgproject.content_rule_auditd_data_retention_space_left_action" selected="true"/>
     <!--6.2.3.1: Ensure changes to system administration scope (sudoers) is collected (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_audit_rules_sysadmin_actions" selected="true"/>
-    <!--6.2.3.10: Ensure successful file system mounts are collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_media_export" selected="true"/>
-    <!--6.2.3.11: Ensure session initiation information is collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_session_events" selected="true"/>
-    <!--6.2.3.12: Ensure login and logout events are collected (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_accounts_passwords_pam_faillock_dir">/var/run/faillock</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_login_events_faillock" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_login_events_lastlog" selected="true"/>
-    <!--6.2.3.13: Ensure file deletion events by users are collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_rename" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_renameat" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_unlink" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_unlinkat" selected="true"/>
-    <!--6.2.3.14: Ensure events that modify the system's Mandatory Access Controls are collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_mac_modification_etc_apparmor" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_mac_modification_etc_apparmor_d" selected="true"/>
-    <!--6.2.3.15: Ensure successful and unsuccessful attempts to use the chcon command are collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_chcon" selected="true"/>
-    <!--6.2.3.16: Ensure successful and unsuccessful attempts to use the setfacl command are collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_setfacl" selected="true"/>
-    <!--6.2.3.17: Ensure successful and unsuccessful attempts to use the chacl command are collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_chacl" selected="true"/>
-    <!--6.2.3.18: Ensure successful and unsuccessful attempts to use the usermod command are collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_usermod" selected="true"/>
-    <!--6.2.3.19: Ensure kernel module loading unloading and modification is collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_delete" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_init" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_finit" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_create" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_query" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_kmod" selected="true"/>
     <!--6.2.3.2: Ensure actions as another user are always logged (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_audit_rules_suid_auid_privilege_function" selected="true"/>
-    <!--6.2.3.20: Ensure the audit configuration is immutable (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_immutable" selected="true"/>
     <!--6.2.3.3: Ensure events that modify the sudo log file are collected (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_audit_sudo_log_events" selected="true"/>
     <!--6.2.3.4: Ensure events that modify date and time information are collected (Automated)-->
@@ -753,10 +720,41 @@
     <select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_lsetxattr" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_removexattr" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_setxattr" selected="true"/>
+    <!--6.2.3.10: Ensure successful file system mounts are collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_media_export" selected="true"/>
+    <!--6.2.3.11: Ensure session initiation information is collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_session_events" selected="true"/>
+    <!--6.2.3.12: Ensure login and logout events are collected (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_accounts_passwords_pam_faillock_dir">/var/run/faillock</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_login_events_faillock" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_login_events_lastlog" selected="true"/>
+    <!--6.2.3.13: Ensure file deletion events by users are collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_rename" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_renameat" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_unlink" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_unlinkat" selected="true"/>
+    <!--6.2.3.14: Ensure events that modify the system's Mandatory Access Controls are collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_mac_modification_etc_apparmor" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_mac_modification_etc_apparmor_d" selected="true"/>
+    <!--6.2.3.15: Ensure successful and unsuccessful attempts to use the chcon command are collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_chcon" selected="true"/>
+    <!--6.2.3.16: Ensure successful and unsuccessful attempts to use the setfacl command are collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_setfacl" selected="true"/>
+    <!--6.2.3.17: Ensure successful and unsuccessful attempts to use the chacl command are collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_chacl" selected="true"/>
+    <!--6.2.3.18: Ensure successful and unsuccessful attempts to use the usermod command are collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_usermod" selected="true"/>
+    <!--6.2.3.19: Ensure kernel module loading unloading and modification is collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_delete" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_init" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_finit" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_create" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_query" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_kmod" selected="true"/>
+    <!--6.2.3.20: Ensure the audit configuration is immutable (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_immutable" selected="true"/>
     <!--6.2.4.1: Ensure audit log files mode is configured (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_var_log_audit" selected="true"/>
-    <!--6.2.4.10: Ensure audit tools group owner is configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupownership_audit_binaries" selected="true"/>
     <!--6.2.4.2: Ensure audit log files owner is configured (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_file_ownership_var_log_audit_stig" selected="true"/>
     <!--6.2.4.3: Ensure audit log files group owner is configured (Automated)-->
@@ -775,6 +773,8 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_audit_binaries" selected="true"/>
     <!--6.2.4.9: Ensure audit tools owner is configured (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_file_ownership_audit_binaries" selected="true"/>
+    <!--6.2.4.10: Ensure audit tools group owner is configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupownership_audit_binaries" selected="true"/>
     <!--6.3.1: Ensure AIDE is installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_aide_build_database" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_package_aide_installed" selected="true"/>
@@ -786,18 +786,6 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_passwd" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_passwd" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_passwd" selected="true"/>
-    <!--7.1.10: Ensure permissions on /etc/security/opasswd are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd_old" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd_old" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd_old" selected="true"/>
-    <!--7.1.11: Ensure world writable files and directories are secured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_unauthorized_world_writable" selected="true"/>
-    <!--7.1.12: Ensure no files or directories without an owner and a group exist (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_no_files_unowned_by_user" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_ungroupowned" selected="true"/>
     <!--7.1.2: Ensure permissions on /etc/passwd- are configured (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_backup_etc_passwd" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_backup_etc_passwd" selected="true"/>
@@ -830,17 +818,20 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_shells" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_shells" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_shells" selected="true"/>
+    <!--7.1.10: Ensure permissions on /etc/security/opasswd are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd_old" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd_old" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd_old" selected="true"/>
+    <!--7.1.11: Ensure world writable files and directories are secured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_unauthorized_world_writable" selected="true"/>
+    <!--7.1.12: Ensure no files or directories without an owner and a group exist (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_no_files_unowned_by_user" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_ungroupowned" selected="true"/>
     <!--7.2.1: Ensure accounts in /etc/passwd use shadowed passwords (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_accounts_password_all_shadowed" selected="true"/>
-    <!--7.2.10: Ensure local interactive user dot files access is configured (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_user_initialization_files_regex">^\.[\w\- ]+$</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_no_rsh_trust_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_no_forward_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_no_netrc_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_user_ownership" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_group_ownership" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_init_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_bash_history" selected="true"/>
     <!--7.2.2: Ensure /etc/shadow password fields are not empty (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_no_empty_passwords_etc_shadow" selected="true"/>
     <!--7.2.3: Ensure all groups in /etc/passwd exist in /etc/group (Automated)-->
@@ -860,5 +851,14 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_groupownership_home_directories" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_ownership_home_directories" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_home_directories" selected="true"/>
+    <!--7.2.10: Ensure local interactive user dot files access is configured (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_user_initialization_files_regex">^\.[\w\- ]+$</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_no_rsh_trust_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_no_forward_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_no_netrc_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_user_ownership" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_group_ownership" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_init_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_bash_history" selected="true"/>
   </Profile>
 </Tailoring>

--- a/tools/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_1/tailoring/cis_level2_workstation-tailoring.xml
+++ b/tools/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_1/tailoring/cis_level2_workstation-tailoring.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Tailoring xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_scap-workbench_tailoring_default">
   <benchmark href="/usr/share/usg-benchmarks/ubuntu2404_CIS_1"/>
-  <version time="2025-09-05T13:35:50+00:00">1</version>
+  <version time="2025-10-08T21:08:51+00:00">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level2_workstation_customized" extends="xccdf_org.ssgproject.content_profile_cis_level2_workstation">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 24.04 Level 2 Workstation Benchmark [CUSTOMIZED]</title>
     <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 24.04 LTS Benchmark, v1.0.0, released 08-26-2024.</description>
@@ -120,8 +120,6 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_issue_net" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_issue_net" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_issue_net" selected="true"/>
-    <!--1.7.10: Ensure XDMCP is not enabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_gnome_gdm_disable_xdmcp" selected="true"/>
     <!--1.7.2: Ensure GDM login banner is configured (Automated)-->
     <set-value idref="xccdf_org.ssgproject.content_value_login_banner_text">^Authorized[\s\n]+users[\s\n]+only\.[\s\n]+All[\s\n]+activity[\s\n]+may[\s\n]+be[\s\n]+monitored[\s\n]+and[\s\n]+reported\.$</set-value>
     <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_banner_enabled" selected="true"/>
@@ -139,9 +137,36 @@
     <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_disable_automount_open" selected="true"/>
     <!--1.7.8: Ensure GDM autorun-never is enabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_disable_autorun" selected="true"/>
+    <!--1.7.10: Ensure XDMCP is not enabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_gnome_gdm_disable_xdmcp" selected="true"/>
     <!--2.1.1: Ensure autofs services are not in use (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_service_autofs_disabled" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_package_autofs_removed" selected="true"/>
+    <!--2.1.2: Ensure avahi daemon services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_avahi_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_avahi-daemon_disabled" selected="true"/>
+    <!--2.1.3: Ensure dhcp server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_dhcp_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd_disabled" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd6_disabled" selected="true"/>
+    <!--2.1.4: Ensure dns server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_bind_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_named_disabled" selected="true"/>
+    <!--2.1.5: Ensure dnsmasq services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_dnsmasq_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dnsmasq_disabled" selected="true"/>
+    <!--2.1.6: Ensure ftp server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_vsftpd_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_vsftpd_disabled" selected="true"/>
+    <!--2.1.7: Ensure ldap server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_openldap-servers_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_slapd_disabled" selected="true"/>
+    <!--2.1.8: Ensure message access server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_dovecot_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dovecot_disabled" selected="true"/>
+    <!--2.1.9: Ensure network file system services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_nfs-kernel-server_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_nfs_disabled" selected="true"/>
     <!--2.1.10: Ensure nis server services are not in use (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_ypserv_removed" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_service_ypserv_disabled" selected="true"/>
@@ -174,35 +199,10 @@
     <!--2.1.19: Ensure xinetd services are not in use (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_xinetd_removed" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_service_xinetd_disabled" selected="true"/>
-    <!--2.1.2: Ensure avahi daemon services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_avahi_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_avahi-daemon_disabled" selected="true"/>
     <!--2.1.21: Ensure mail transfer agent is configured for local-only mode (Automated)-->
     <set-value idref="xccdf_org.ssgproject.content_value_var_postfix_inet_interfaces">loopback-only</set-value>
     <select idref="xccdf_org.ssgproject.content_rule_has_nonlocal_mta" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_postfix_network_listening_disabled" selected="true"/>
-    <!--2.1.3: Ensure dhcp server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_dhcp_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd_disabled" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd6_disabled" selected="true"/>
-    <!--2.1.4: Ensure dns server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_bind_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_named_disabled" selected="true"/>
-    <!--2.1.5: Ensure dnsmasq services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_dnsmasq_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dnsmasq_disabled" selected="true"/>
-    <!--2.1.6: Ensure ftp server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_vsftpd_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_vsftpd_disabled" selected="true"/>
-    <!--2.1.7: Ensure ldap server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_openldap-servers_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_slapd_disabled" selected="true"/>
-    <!--2.1.8: Ensure message access server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_dovecot_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dovecot_disabled" selected="true"/>
-    <!--2.1.9: Ensure network file system services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_nfs-kernel-server_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_nfs_disabled" selected="true"/>
     <!--2.2.1: Ensure NIS Client is not installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_nis_removed" selected="true"/>
     <!--2.2.2: Ensure rsh client is not installed (Automated)-->
@@ -288,11 +288,6 @@
     <!--3.3.1: Ensure ip forwarding is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_forwarding" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_ip_forward" selected="true"/>
-    <!--3.3.10: Ensure tcp syn cookies is enabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_tcp_syncookies" selected="true"/>
-    <!--3.3.11: Ensure ipv6 router advertisements are not accepted (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_accept_ra" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_default_accept_ra" selected="true"/>
     <!--3.3.2: Ensure packet redirect sending is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_send_redirects" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_send_redirects" selected="true"/>
@@ -319,6 +314,11 @@
     <!--3.3.9: Ensure suspicious packets are logged (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_log_martians" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_log_martians" selected="true"/>
+    <!--3.3.10: Ensure tcp syn cookies is enabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_tcp_syncookies" selected="true"/>
+    <!--3.3.11: Ensure ipv6 router advertisements are not accepted (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_accept_ra" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_default_accept_ra" selected="true"/>
     <!--4.1.1: Ensure a single firewall configuration utility is in use (Automated)-->
     <set-value idref="xccdf_org.ssgproject.content_value_var_network_filtering_service">nftables</set-value>
     <select idref="xccdf_org.ssgproject.content_rule_firewall_single_service_active" selected="true"/>
@@ -337,9 +337,6 @@
     <select idref="xccdf_org.ssgproject.content_rule_set_ufw_default_rule" selected="true"/>
     <!--4.3.1: Ensure nftables is installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_nftables_installed" selected="true"/>
-    <!--4.3.10: Ensure nftables rules are permanent (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_nftables_master_config_file">/etc/nftables.conf</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_nftables_rules_permanent" selected="true"/>
     <!--4.3.2: Ensure ufw is uninstalled or disabled with nftables (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_ufw_removed" selected="true"/>
     <!--4.3.4: Ensure a nftables table exists (Automated)-->
@@ -359,6 +356,9 @@
     <select idref="xccdf_org.ssgproject.content_rule_nftables_ensure_default_deny_policy" selected="true"/>
     <!--4.3.9: Ensure nftables service is enabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_service_nftables_enabled" selected="true"/>
+    <!--4.3.10: Ensure nftables rules are permanent (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_nftables_master_config_file">/etc/nftables.conf</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_nftables_rules_permanent" selected="true"/>
     <!--4.4.1.1: Ensure iptables packages are installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_iptables-persistent_installed" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_package_iptables_installed" selected="true"/>
@@ -380,6 +380,25 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_sshd_config" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_sshd_config" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_config" selected="true"/>
+    <!--5.1.2: Ensure permissions on SSH private host key files are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_private_key" selected="true"/>
+    <!--5.1.3: Ensure permissions on SSH public host key files are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_pub_key" selected="true"/>
+    <!--5.1.4: Ensure sshd access is configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_limit_user_access" selected="true"/>
+    <!--5.1.5: Ensure sshd Banner is configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_enable_warning_banner_net" selected="true"/>
+    <!--5.1.6: Ensure sshd Ciphers are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_use_strong_ciphers" selected="true"/>
+    <!--5.1.7: Ensure sshd ClientAliveInterval and ClientAliveCountMax are configured (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_sshd_idle_timeout_value">300</set-value>
+    <set-value idref="xccdf_org.ssgproject.content_value_var_sshd_set_keepalive">3</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_idle_timeout" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_keepalive" selected="true"/>
+    <!--5.1.8: Ensure sshd DisableForwarding is enabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_forwarding" selected="true"/>
+    <!--5.1.9: Ensure sshd GSSAPIAuthentication is disabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_gssapi_auth" selected="true"/>
     <!--5.1.10: Ensure sshd HostbasedAuthentication is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_disable_host_auth" selected="true"/>
     <!--5.1.11: Ensure sshd IgnoreRhosts is enabled (Automated)-->
@@ -406,31 +425,12 @@
     <select idref="xccdf_org.ssgproject.content_rule_sshd_set_maxstartups" selected="true"/>
     <!--5.1.19: Ensure sshd PermitEmptyPasswords is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_empty_passwords" selected="true"/>
-    <!--5.1.2: Ensure permissions on SSH private host key files are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_private_key" selected="true"/>
     <!--5.1.20: Ensure sshd PermitRootLogin is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_root_login" selected="true"/>
     <!--5.1.21: Ensure sshd PermitUserEnvironment is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_do_not_permit_user_env" selected="true"/>
     <!--5.1.22: Ensure sshd UsePAM is enabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_enable_pam" selected="true"/>
-    <!--5.1.3: Ensure permissions on SSH public host key files are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_pub_key" selected="true"/>
-    <!--5.1.4: Ensure sshd access is configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_limit_user_access" selected="true"/>
-    <!--5.1.5: Ensure sshd Banner is configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_enable_warning_banner_net" selected="true"/>
-    <!--5.1.6: Ensure sshd Ciphers are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_use_strong_ciphers" selected="true"/>
-    <!--5.1.7: Ensure sshd ClientAliveInterval and ClientAliveCountMax are configured (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_sshd_idle_timeout_value">300</set-value>
-    <set-value idref="xccdf_org.ssgproject.content_value_var_sshd_set_keepalive">3</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_idle_timeout" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_keepalive" selected="true"/>
-    <!--5.1.8: Ensure sshd DisableForwarding is enabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_forwarding" selected="true"/>
-    <!--5.1.9: Ensure sshd GSSAPIAuthentication is disabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_gssapi_auth" selected="true"/>
     <!--5.2.1: Ensure sudo is installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_sudo_installed" selected="true"/>
     <!--5.2.2: Ensure sudo commands use pty (Automated)-->
@@ -672,41 +672,8 @@
     <select idref="xccdf_org.ssgproject.content_rule_auditd_data_retention_space_left_action" selected="true"/>
     <!--6.2.3.1: Ensure changes to system administration scope (sudoers) is collected (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_audit_rules_sysadmin_actions" selected="true"/>
-    <!--6.2.3.10: Ensure successful file system mounts are collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_media_export" selected="true"/>
-    <!--6.2.3.11: Ensure session initiation information is collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_session_events" selected="true"/>
-    <!--6.2.3.12: Ensure login and logout events are collected (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_accounts_passwords_pam_faillock_dir">/var/run/faillock</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_login_events_faillock" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_login_events_lastlog" selected="true"/>
-    <!--6.2.3.13: Ensure file deletion events by users are collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_rename" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_renameat" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_unlink" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_unlinkat" selected="true"/>
-    <!--6.2.3.14: Ensure events that modify the system's Mandatory Access Controls are collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_mac_modification_etc_apparmor" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_mac_modification_etc_apparmor_d" selected="true"/>
-    <!--6.2.3.15: Ensure successful and unsuccessful attempts to use the chcon command are collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_chcon" selected="true"/>
-    <!--6.2.3.16: Ensure successful and unsuccessful attempts to use the setfacl command are collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_setfacl" selected="true"/>
-    <!--6.2.3.17: Ensure successful and unsuccessful attempts to use the chacl command are collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_chacl" selected="true"/>
-    <!--6.2.3.18: Ensure successful and unsuccessful attempts to use the usermod command are collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_usermod" selected="true"/>
-    <!--6.2.3.19: Ensure kernel module loading unloading and modification is collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_delete" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_init" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_finit" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_create" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_query" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_kmod" selected="true"/>
     <!--6.2.3.2: Ensure actions as another user are always logged (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_audit_rules_suid_auid_privilege_function" selected="true"/>
-    <!--6.2.3.20: Ensure the audit configuration is immutable (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_immutable" selected="true"/>
     <!--6.2.3.3: Ensure events that modify the sudo log file are collected (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_audit_sudo_log_events" selected="true"/>
     <!--6.2.3.4: Ensure events that modify date and time information are collected (Automated)-->
@@ -747,10 +714,41 @@
     <select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_lsetxattr" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_removexattr" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_setxattr" selected="true"/>
+    <!--6.2.3.10: Ensure successful file system mounts are collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_media_export" selected="true"/>
+    <!--6.2.3.11: Ensure session initiation information is collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_session_events" selected="true"/>
+    <!--6.2.3.12: Ensure login and logout events are collected (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_accounts_passwords_pam_faillock_dir">/var/run/faillock</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_login_events_faillock" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_login_events_lastlog" selected="true"/>
+    <!--6.2.3.13: Ensure file deletion events by users are collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_rename" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_renameat" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_unlink" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_unlinkat" selected="true"/>
+    <!--6.2.3.14: Ensure events that modify the system's Mandatory Access Controls are collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_mac_modification_etc_apparmor" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_mac_modification_etc_apparmor_d" selected="true"/>
+    <!--6.2.3.15: Ensure successful and unsuccessful attempts to use the chcon command are collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_chcon" selected="true"/>
+    <!--6.2.3.16: Ensure successful and unsuccessful attempts to use the setfacl command are collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_setfacl" selected="true"/>
+    <!--6.2.3.17: Ensure successful and unsuccessful attempts to use the chacl command are collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_chacl" selected="true"/>
+    <!--6.2.3.18: Ensure successful and unsuccessful attempts to use the usermod command are collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_usermod" selected="true"/>
+    <!--6.2.3.19: Ensure kernel module loading unloading and modification is collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_delete" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_init" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_finit" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_create" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_query" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_kmod" selected="true"/>
+    <!--6.2.3.20: Ensure the audit configuration is immutable (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_immutable" selected="true"/>
     <!--6.2.4.1: Ensure audit log files mode is configured (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_var_log_audit" selected="true"/>
-    <!--6.2.4.10: Ensure audit tools group owner is configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupownership_audit_binaries" selected="true"/>
     <!--6.2.4.2: Ensure audit log files owner is configured (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_file_ownership_var_log_audit_stig" selected="true"/>
     <!--6.2.4.3: Ensure audit log files group owner is configured (Automated)-->
@@ -769,6 +767,8 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_audit_binaries" selected="true"/>
     <!--6.2.4.9: Ensure audit tools owner is configured (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_file_ownership_audit_binaries" selected="true"/>
+    <!--6.2.4.10: Ensure audit tools group owner is configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupownership_audit_binaries" selected="true"/>
     <!--6.3.1: Ensure AIDE is installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_aide_build_database" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_package_aide_installed" selected="true"/>
@@ -780,18 +780,6 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_passwd" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_passwd" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_passwd" selected="true"/>
-    <!--7.1.10: Ensure permissions on /etc/security/opasswd are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd_old" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd_old" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd_old" selected="true"/>
-    <!--7.1.11: Ensure world writable files and directories are secured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_unauthorized_world_writable" selected="true"/>
-    <!--7.1.12: Ensure no files or directories without an owner and a group exist (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_no_files_unowned_by_user" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_ungroupowned" selected="true"/>
     <!--7.1.2: Ensure permissions on /etc/passwd- are configured (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_backup_etc_passwd" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_backup_etc_passwd" selected="true"/>
@@ -824,17 +812,20 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_shells" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_shells" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_shells" selected="true"/>
+    <!--7.1.10: Ensure permissions on /etc/security/opasswd are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd_old" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd_old" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd_old" selected="true"/>
+    <!--7.1.11: Ensure world writable files and directories are secured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_unauthorized_world_writable" selected="true"/>
+    <!--7.1.12: Ensure no files or directories without an owner and a group exist (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_no_files_unowned_by_user" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_ungroupowned" selected="true"/>
     <!--7.2.1: Ensure accounts in /etc/passwd use shadowed passwords (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_accounts_password_all_shadowed" selected="true"/>
-    <!--7.2.10: Ensure local interactive user dot files access is configured (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_user_initialization_files_regex">^\.[\w\- ]+$</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_no_rsh_trust_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_no_forward_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_no_netrc_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_user_ownership" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_group_ownership" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_init_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_bash_history" selected="true"/>
     <!--7.2.2: Ensure /etc/shadow password fields are not empty (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_no_empty_passwords_etc_shadow" selected="true"/>
     <!--7.2.3: Ensure all groups in /etc/passwd exist in /etc/group (Automated)-->
@@ -854,5 +845,14 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_groupownership_home_directories" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_ownership_home_directories" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_home_directories" selected="true"/>
+    <!--7.2.10: Ensure local interactive user dot files access is configured (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_user_initialization_files_regex">^\.[\w\- ]+$</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_no_rsh_trust_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_no_forward_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_no_netrc_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_user_ownership" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_group_ownership" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_init_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_bash_history" selected="true"/>
   </Profile>
 </Tailoring>

--- a/tools/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_2/tailoring/cis_level1_server-tailoring.xml
+++ b/tools/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_2/tailoring/cis_level1_server-tailoring.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Tailoring xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_scap-workbench_tailoring_default">
   <benchmark href="/usr/share/usg-benchmarks/ubuntu2404_CIS_2"/>
-  <version time="2025-09-05T13:35:50+00:00">1</version>
+  <version time="2025-10-08T21:08:51+00:00">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level1_server_customized" extends="xccdf_org.ssgproject.content_profile_cis_level1_server">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 24.04 Level 1 Server Benchmark [CUSTOMIZED]</title>
     <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 24.04 LTS Benchmark, v1.0.0, released 08-26-2024.</description>
@@ -104,8 +104,6 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_issue_net" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_issue_net" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_issue_net" selected="true"/>
-    <!--1.7.10: Ensure XDMCP is not enabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_gnome_gdm_disable_xdmcp" selected="true"/>
     <!--1.7.2: Ensure GDM login banner is configured (Automated)-->
     <set-value idref="xccdf_org.ssgproject.content_value_login_banner_text">^Authorized[\s\n]+users[\s\n]+only\.[\s\n]+All[\s\n]+activity[\s\n]+may[\s\n]+be[\s\n]+monitored[\s\n]+and[\s\n]+reported\.$</set-value>
     <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_banner_enabled" selected="true"/>
@@ -123,9 +121,36 @@
     <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_disable_automount_open" selected="true"/>
     <!--1.7.8: Ensure GDM autorun-never is enabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_disable_autorun" selected="true"/>
+    <!--1.7.10: Ensure XDMCP is not enabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_gnome_gdm_disable_xdmcp" selected="true"/>
     <!--2.1.1: Ensure autofs services are not in use (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_service_autofs_disabled" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_package_autofs_removed" selected="true"/>
+    <!--2.1.2: Ensure avahi daemon services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_avahi_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_avahi-daemon_disabled" selected="true"/>
+    <!--2.1.3: Ensure dhcp server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_dhcp_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd_disabled" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd6_disabled" selected="true"/>
+    <!--2.1.4: Ensure dns server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_bind_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_named_disabled" selected="true"/>
+    <!--2.1.5: Ensure dnsmasq services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_dnsmasq_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dnsmasq_disabled" selected="true"/>
+    <!--2.1.6: Ensure ftp server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_vsftpd_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_vsftpd_disabled" selected="true"/>
+    <!--2.1.7: Ensure ldap server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_openldap-servers_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_slapd_disabled" selected="true"/>
+    <!--2.1.8: Ensure message access server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_dovecot_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dovecot_disabled" selected="true"/>
+    <!--2.1.9: Ensure network file system services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_nfs-kernel-server_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_nfs_disabled" selected="true"/>
     <!--2.1.10: Ensure nis server services are not in use (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_ypserv_removed" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_service_ypserv_disabled" selected="true"/>
@@ -158,35 +183,10 @@
     <!--2.1.19: Ensure xinetd services are not in use (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_xinetd_removed" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_service_xinetd_disabled" selected="true"/>
-    <!--2.1.2: Ensure avahi daemon services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_avahi_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_avahi-daemon_disabled" selected="true"/>
     <!--2.1.21: Ensure mail transfer agent is configured for local-only mode (Automated)-->
     <set-value idref="xccdf_org.ssgproject.content_value_var_postfix_inet_interfaces">loopback-only</set-value>
     <select idref="xccdf_org.ssgproject.content_rule_has_nonlocal_mta" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_postfix_network_listening_disabled" selected="true"/>
-    <!--2.1.3: Ensure dhcp server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_dhcp_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd_disabled" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd6_disabled" selected="true"/>
-    <!--2.1.4: Ensure dns server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_bind_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_named_disabled" selected="true"/>
-    <!--2.1.5: Ensure dnsmasq services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_dnsmasq_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dnsmasq_disabled" selected="true"/>
-    <!--2.1.6: Ensure ftp server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_vsftpd_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_vsftpd_disabled" selected="true"/>
-    <!--2.1.7: Ensure ldap server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_openldap-servers_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_slapd_disabled" selected="true"/>
-    <!--2.1.8: Ensure message access server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_dovecot_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dovecot_disabled" selected="true"/>
-    <!--2.1.9: Ensure network file system services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_nfs-kernel-server_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_nfs_disabled" selected="true"/>
     <!--2.2.1: Ensure NIS Client is not installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_nis_removed" selected="true"/>
     <!--2.2.2: Ensure rsh client is not installed (Automated)-->
@@ -266,11 +266,6 @@
     <!--3.3.1: Ensure ip forwarding is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_forwarding" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_ip_forward" selected="true"/>
-    <!--3.3.10: Ensure tcp syn cookies is enabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_tcp_syncookies" selected="true"/>
-    <!--3.3.11: Ensure ipv6 router advertisements are not accepted (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_accept_ra" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_default_accept_ra" selected="true"/>
     <!--3.3.2: Ensure packet redirect sending is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_send_redirects" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_send_redirects" selected="true"/>
@@ -297,6 +292,11 @@
     <!--3.3.9: Ensure suspicious packets are logged (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_log_martians" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_log_martians" selected="true"/>
+    <!--3.3.10: Ensure tcp syn cookies is enabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_tcp_syncookies" selected="true"/>
+    <!--3.3.11: Ensure ipv6 router advertisements are not accepted (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_accept_ra" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_default_accept_ra" selected="true"/>
     <!--4.1.1: Ensure a single firewall configuration utility is in use (Automated)-->
     <set-value idref="xccdf_org.ssgproject.content_value_var_network_filtering_service">nftables</set-value>
     <select idref="xccdf_org.ssgproject.content_rule_firewall_single_service_active" selected="true"/>
@@ -315,9 +315,6 @@
     <select idref="xccdf_org.ssgproject.content_rule_set_ufw_default_rule" selected="true"/>
     <!--4.3.1: Ensure nftables is installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_nftables_installed" selected="true"/>
-    <!--4.3.10: Ensure nftables rules are permanent (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_nftables_master_config_file">/etc/nftables.conf</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_nftables_rules_permanent" selected="true"/>
     <!--4.3.2: Ensure ufw is uninstalled or disabled with nftables (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_ufw_removed" selected="true"/>
     <!--4.3.4: Ensure a nftables table exists (Automated)-->
@@ -337,6 +334,9 @@
     <select idref="xccdf_org.ssgproject.content_rule_nftables_ensure_default_deny_policy" selected="true"/>
     <!--4.3.9: Ensure nftables service is enabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_service_nftables_enabled" selected="true"/>
+    <!--4.3.10: Ensure nftables rules are permanent (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_nftables_master_config_file">/etc/nftables.conf</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_nftables_rules_permanent" selected="true"/>
     <!--4.4.1.1: Ensure iptables packages are installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_iptables-persistent_installed" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_package_iptables_installed" selected="true"/>
@@ -358,6 +358,21 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_sshd_config" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_sshd_config" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_config" selected="true"/>
+    <!--5.1.2: Ensure permissions on SSH private host key files are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_private_key" selected="true"/>
+    <!--5.1.3: Ensure permissions on SSH public host key files are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_pub_key" selected="true"/>
+    <!--5.1.4: Ensure sshd access is configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_limit_user_access" selected="true"/>
+    <!--5.1.5: Ensure sshd Banner is configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_enable_warning_banner_net" selected="true"/>
+    <!--5.1.6: Ensure sshd Ciphers are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_use_strong_ciphers" selected="true"/>
+    <!--5.1.7: Ensure sshd ClientAliveInterval and ClientAliveCountMax are configured (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_sshd_idle_timeout_value">300</set-value>
+    <set-value idref="xccdf_org.ssgproject.content_value_var_sshd_set_keepalive">3</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_idle_timeout" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_keepalive" selected="true"/>
     <!--5.1.10: Ensure sshd HostbasedAuthentication is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_disable_host_auth" selected="true"/>
     <!--5.1.11: Ensure sshd IgnoreRhosts is enabled (Automated)-->
@@ -384,27 +399,12 @@
     <select idref="xccdf_org.ssgproject.content_rule_sshd_set_maxstartups" selected="true"/>
     <!--5.1.19: Ensure sshd PermitEmptyPasswords is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_empty_passwords" selected="true"/>
-    <!--5.1.2: Ensure permissions on SSH private host key files are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_private_key" selected="true"/>
     <!--5.1.20: Ensure sshd PermitRootLogin is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_root_login" selected="true"/>
     <!--5.1.21: Ensure sshd PermitUserEnvironment is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_do_not_permit_user_env" selected="true"/>
     <!--5.1.22: Ensure sshd UsePAM is enabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_enable_pam" selected="true"/>
-    <!--5.1.3: Ensure permissions on SSH public host key files are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_pub_key" selected="true"/>
-    <!--5.1.4: Ensure sshd access is configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_limit_user_access" selected="true"/>
-    <!--5.1.5: Ensure sshd Banner is configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_enable_warning_banner_net" selected="true"/>
-    <!--5.1.6: Ensure sshd Ciphers are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_use_strong_ciphers" selected="true"/>
-    <!--5.1.7: Ensure sshd ClientAliveInterval and ClientAliveCountMax are configured (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_sshd_idle_timeout_value">300</set-value>
-    <set-value idref="xccdf_org.ssgproject.content_value_var_sshd_set_keepalive">3</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_idle_timeout" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_keepalive" selected="true"/>
     <!--5.2.1: Ensure sudo is installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_sudo_installed" selected="true"/>
     <!--5.2.2: Ensure sudo commands use pty (Automated)-->
@@ -614,18 +614,6 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_passwd" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_passwd" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_passwd" selected="true"/>
-    <!--7.1.10: Ensure permissions on /etc/security/opasswd are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd_old" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd_old" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd_old" selected="true"/>
-    <!--7.1.11: Ensure world writable files and directories are secured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_unauthorized_world_writable" selected="true"/>
-    <!--7.1.12: Ensure no files or directories without an owner and a group exist (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_no_files_unowned_by_user" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_ungroupowned" selected="true"/>
     <!--7.1.2: Ensure permissions on /etc/passwd- are configured (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_backup_etc_passwd" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_backup_etc_passwd" selected="true"/>
@@ -658,17 +646,20 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_shells" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_shells" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_shells" selected="true"/>
+    <!--7.1.10: Ensure permissions on /etc/security/opasswd are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd_old" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd_old" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd_old" selected="true"/>
+    <!--7.1.11: Ensure world writable files and directories are secured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_unauthorized_world_writable" selected="true"/>
+    <!--7.1.12: Ensure no files or directories without an owner and a group exist (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_no_files_unowned_by_user" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_ungroupowned" selected="true"/>
     <!--7.2.1: Ensure accounts in /etc/passwd use shadowed passwords (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_accounts_password_all_shadowed" selected="true"/>
-    <!--7.2.10: Ensure local interactive user dot files access is configured (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_user_initialization_files_regex">^\.[\w\- ]+$</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_no_rsh_trust_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_no_forward_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_no_netrc_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_user_ownership" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_group_ownership" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_init_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_bash_history" selected="true"/>
     <!--7.2.2: Ensure /etc/shadow password fields are not empty (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_no_empty_passwords_etc_shadow" selected="true"/>
     <!--7.2.3: Ensure all groups in /etc/passwd exist in /etc/group (Automated)-->
@@ -688,5 +679,14 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_groupownership_home_directories" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_ownership_home_directories" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_home_directories" selected="true"/>
+    <!--7.2.10: Ensure local interactive user dot files access is configured (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_user_initialization_files_regex">^\.[\w\- ]+$</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_no_rsh_trust_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_no_forward_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_no_netrc_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_user_ownership" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_group_ownership" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_init_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_bash_history" selected="true"/>
   </Profile>
 </Tailoring>

--- a/tools/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_2/tailoring/cis_level1_workstation-tailoring.xml
+++ b/tools/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_2/tailoring/cis_level1_workstation-tailoring.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Tailoring xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_scap-workbench_tailoring_default">
   <benchmark href="/usr/share/usg-benchmarks/ubuntu2404_CIS_2"/>
-  <version time="2025-09-05T13:35:51+00:00">1</version>
+  <version time="2025-10-08T21:08:52+00:00">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level1_workstation_customized" extends="xccdf_org.ssgproject.content_profile_cis_level1_workstation">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 24.04 Level 1 Workstation Benchmark [CUSTOMIZED]</title>
     <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 24.04 LTS Benchmark, v1.0.0, released 08-26-2024.</description>
@@ -102,8 +102,6 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_issue_net" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_issue_net" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_issue_net" selected="true"/>
-    <!--1.7.10: Ensure XDMCP is not enabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_gnome_gdm_disable_xdmcp" selected="true"/>
     <!--1.7.2: Ensure GDM login banner is configured (Automated)-->
     <set-value idref="xccdf_org.ssgproject.content_value_login_banner_text">^Authorized[\s\n]+users[\s\n]+only\.[\s\n]+All[\s\n]+activity[\s\n]+may[\s\n]+be[\s\n]+monitored[\s\n]+and[\s\n]+reported\.$</set-value>
     <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_banner_enabled" selected="true"/>
@@ -118,6 +116,30 @@
     <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_screensaver_lock_delay" selected="true"/>
     <!--1.7.8: Ensure GDM autorun-never is enabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_disable_autorun" selected="true"/>
+    <!--1.7.10: Ensure XDMCP is not enabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_gnome_gdm_disable_xdmcp" selected="true"/>
+    <!--2.1.3: Ensure dhcp server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_dhcp_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd_disabled" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd6_disabled" selected="true"/>
+    <!--2.1.4: Ensure dns server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_bind_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_named_disabled" selected="true"/>
+    <!--2.1.5: Ensure dnsmasq services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_dnsmasq_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dnsmasq_disabled" selected="true"/>
+    <!--2.1.6: Ensure ftp server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_vsftpd_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_vsftpd_disabled" selected="true"/>
+    <!--2.1.7: Ensure ldap server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_openldap-servers_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_slapd_disabled" selected="true"/>
+    <!--2.1.8: Ensure message access server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_dovecot_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dovecot_disabled" selected="true"/>
+    <!--2.1.9: Ensure network file system services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_nfs-kernel-server_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_nfs_disabled" selected="true"/>
     <!--2.1.10: Ensure nis server services are not in use (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_ypserv_removed" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_service_ypserv_disabled" selected="true"/>
@@ -151,28 +173,6 @@
     <set-value idref="xccdf_org.ssgproject.content_value_var_postfix_inet_interfaces">loopback-only</set-value>
     <select idref="xccdf_org.ssgproject.content_rule_has_nonlocal_mta" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_postfix_network_listening_disabled" selected="true"/>
-    <!--2.1.3: Ensure dhcp server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_dhcp_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd_disabled" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd6_disabled" selected="true"/>
-    <!--2.1.4: Ensure dns server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_bind_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_named_disabled" selected="true"/>
-    <!--2.1.5: Ensure dnsmasq services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_dnsmasq_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dnsmasq_disabled" selected="true"/>
-    <!--2.1.6: Ensure ftp server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_vsftpd_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_vsftpd_disabled" selected="true"/>
-    <!--2.1.7: Ensure ldap server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_openldap-servers_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_slapd_disabled" selected="true"/>
-    <!--2.1.8: Ensure message access server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_dovecot_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dovecot_disabled" selected="true"/>
-    <!--2.1.9: Ensure network file system services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_nfs-kernel-server_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_nfs_disabled" selected="true"/>
     <!--2.2.1: Ensure NIS Client is not installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_nis_removed" selected="true"/>
     <!--2.2.2: Ensure rsh client is not installed (Automated)-->
@@ -248,11 +248,6 @@
     <!--3.3.1: Ensure ip forwarding is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_forwarding" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_ip_forward" selected="true"/>
-    <!--3.3.10: Ensure tcp syn cookies is enabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_tcp_syncookies" selected="true"/>
-    <!--3.3.11: Ensure ipv6 router advertisements are not accepted (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_accept_ra" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_default_accept_ra" selected="true"/>
     <!--3.3.2: Ensure packet redirect sending is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_send_redirects" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_send_redirects" selected="true"/>
@@ -279,6 +274,11 @@
     <!--3.3.9: Ensure suspicious packets are logged (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_log_martians" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_log_martians" selected="true"/>
+    <!--3.3.10: Ensure tcp syn cookies is enabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_tcp_syncookies" selected="true"/>
+    <!--3.3.11: Ensure ipv6 router advertisements are not accepted (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_accept_ra" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_default_accept_ra" selected="true"/>
     <!--4.1.1: Ensure a single firewall configuration utility is in use (Automated)-->
     <set-value idref="xccdf_org.ssgproject.content_value_var_network_filtering_service">nftables</set-value>
     <select idref="xccdf_org.ssgproject.content_rule_firewall_single_service_active" selected="true"/>
@@ -297,9 +297,6 @@
     <select idref="xccdf_org.ssgproject.content_rule_set_ufw_default_rule" selected="true"/>
     <!--4.3.1: Ensure nftables is installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_nftables_installed" selected="true"/>
-    <!--4.3.10: Ensure nftables rules are permanent (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_nftables_master_config_file">/etc/nftables.conf</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_nftables_rules_permanent" selected="true"/>
     <!--4.3.2: Ensure ufw is uninstalled or disabled with nftables (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_ufw_removed" selected="true"/>
     <!--4.3.4: Ensure a nftables table exists (Automated)-->
@@ -319,6 +316,9 @@
     <select idref="xccdf_org.ssgproject.content_rule_nftables_ensure_default_deny_policy" selected="true"/>
     <!--4.3.9: Ensure nftables service is enabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_service_nftables_enabled" selected="true"/>
+    <!--4.3.10: Ensure nftables rules are permanent (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_nftables_master_config_file">/etc/nftables.conf</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_nftables_rules_permanent" selected="true"/>
     <!--4.4.1.1: Ensure iptables packages are installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_iptables-persistent_installed" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_package_iptables_installed" selected="true"/>
@@ -340,6 +340,25 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_sshd_config" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_sshd_config" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_config" selected="true"/>
+    <!--5.1.2: Ensure permissions on SSH private host key files are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_private_key" selected="true"/>
+    <!--5.1.3: Ensure permissions on SSH public host key files are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_pub_key" selected="true"/>
+    <!--5.1.4: Ensure sshd access is configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_limit_user_access" selected="true"/>
+    <!--5.1.5: Ensure sshd Banner is configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_enable_warning_banner_net" selected="true"/>
+    <!--5.1.6: Ensure sshd Ciphers are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_use_strong_ciphers" selected="true"/>
+    <!--5.1.7: Ensure sshd ClientAliveInterval and ClientAliveCountMax are configured (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_sshd_idle_timeout_value">300</set-value>
+    <set-value idref="xccdf_org.ssgproject.content_value_var_sshd_set_keepalive">3</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_idle_timeout" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_keepalive" selected="true"/>
+    <!--5.1.8: Ensure sshd DisableForwarding is enabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_forwarding" selected="true"/>
+    <!--5.1.9: Ensure sshd GSSAPIAuthentication is disabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_gssapi_auth" selected="true"/>
     <!--5.1.10: Ensure sshd HostbasedAuthentication is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_disable_host_auth" selected="true"/>
     <!--5.1.11: Ensure sshd IgnoreRhosts is enabled (Automated)-->
@@ -366,31 +385,12 @@
     <select idref="xccdf_org.ssgproject.content_rule_sshd_set_maxstartups" selected="true"/>
     <!--5.1.19: Ensure sshd PermitEmptyPasswords is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_empty_passwords" selected="true"/>
-    <!--5.1.2: Ensure permissions on SSH private host key files are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_private_key" selected="true"/>
     <!--5.1.20: Ensure sshd PermitRootLogin is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_root_login" selected="true"/>
     <!--5.1.21: Ensure sshd PermitUserEnvironment is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_do_not_permit_user_env" selected="true"/>
     <!--5.1.22: Ensure sshd UsePAM is enabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_enable_pam" selected="true"/>
-    <!--5.1.3: Ensure permissions on SSH public host key files are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_pub_key" selected="true"/>
-    <!--5.1.4: Ensure sshd access is configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_limit_user_access" selected="true"/>
-    <!--5.1.5: Ensure sshd Banner is configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_enable_warning_banner_net" selected="true"/>
-    <!--5.1.6: Ensure sshd Ciphers are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_use_strong_ciphers" selected="true"/>
-    <!--5.1.7: Ensure sshd ClientAliveInterval and ClientAliveCountMax are configured (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_sshd_idle_timeout_value">300</set-value>
-    <set-value idref="xccdf_org.ssgproject.content_value_var_sshd_set_keepalive">3</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_idle_timeout" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_keepalive" selected="true"/>
-    <!--5.1.8: Ensure sshd DisableForwarding is enabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_forwarding" selected="true"/>
-    <!--5.1.9: Ensure sshd GSSAPIAuthentication is disabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_gssapi_auth" selected="true"/>
     <!--5.2.1: Ensure sudo is installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_sudo_installed" selected="true"/>
     <!--5.2.2: Ensure sudo commands use pty (Automated)-->
@@ -600,18 +600,6 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_passwd" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_passwd" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_passwd" selected="true"/>
-    <!--7.1.10: Ensure permissions on /etc/security/opasswd are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd_old" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd_old" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd_old" selected="true"/>
-    <!--7.1.11: Ensure world writable files and directories are secured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_unauthorized_world_writable" selected="true"/>
-    <!--7.1.12: Ensure no files or directories without an owner and a group exist (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_no_files_unowned_by_user" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_ungroupowned" selected="true"/>
     <!--7.1.2: Ensure permissions on /etc/passwd- are configured (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_backup_etc_passwd" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_backup_etc_passwd" selected="true"/>
@@ -644,17 +632,20 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_shells" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_shells" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_shells" selected="true"/>
+    <!--7.1.10: Ensure permissions on /etc/security/opasswd are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd_old" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd_old" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd_old" selected="true"/>
+    <!--7.1.11: Ensure world writable files and directories are secured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_unauthorized_world_writable" selected="true"/>
+    <!--7.1.12: Ensure no files or directories without an owner and a group exist (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_no_files_unowned_by_user" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_ungroupowned" selected="true"/>
     <!--7.2.1: Ensure accounts in /etc/passwd use shadowed passwords (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_accounts_password_all_shadowed" selected="true"/>
-    <!--7.2.10: Ensure local interactive user dot files access is configured (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_user_initialization_files_regex">^\.[\w\- ]+$</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_no_rsh_trust_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_no_forward_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_no_netrc_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_user_ownership" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_group_ownership" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_init_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_bash_history" selected="true"/>
     <!--7.2.2: Ensure /etc/shadow password fields are not empty (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_no_empty_passwords_etc_shadow" selected="true"/>
     <!--7.2.3: Ensure all groups in /etc/passwd exist in /etc/group (Automated)-->
@@ -674,5 +665,14 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_groupownership_home_directories" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_ownership_home_directories" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_home_directories" selected="true"/>
+    <!--7.2.10: Ensure local interactive user dot files access is configured (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_user_initialization_files_regex">^\.[\w\- ]+$</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_no_rsh_trust_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_no_forward_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_no_netrc_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_user_ownership" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_group_ownership" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_init_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_bash_history" selected="true"/>
   </Profile>
 </Tailoring>

--- a/tools/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_2/tailoring/cis_level2_server-tailoring.xml
+++ b/tools/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_2/tailoring/cis_level2_server-tailoring.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Tailoring xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_scap-workbench_tailoring_default">
   <benchmark href="/usr/share/usg-benchmarks/ubuntu2404_CIS_2"/>
-  <version time="2025-09-05T13:35:51+00:00">1</version>
+  <version time="2025-10-08T21:08:52+00:00">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level2_server_customized" extends="xccdf_org.ssgproject.content_profile_cis_level2_server">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 24.04 Level 2 Server Benchmark [CUSTOMIZED]</title>
     <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 24.04 LTS Benchmark, v1.0.0, released 08-26-2024.</description>
@@ -122,8 +122,6 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_issue_net" selected="true"/>
     <!--1.7.1: Ensure GDM is removed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_gdm_removed" selected="true"/>
-    <!--1.7.10: Ensure XDMCP is not enabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_gnome_gdm_disable_xdmcp" selected="true"/>
     <!--1.7.2: Ensure GDM login banner is configured (Automated)-->
     <set-value idref="xccdf_org.ssgproject.content_value_login_banner_text">^Authorized[\s\n]+users[\s\n]+only\.[\s\n]+All[\s\n]+activity[\s\n]+may[\s\n]+be[\s\n]+monitored[\s\n]+and[\s\n]+reported\.$</set-value>
     <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_banner_enabled" selected="true"/>
@@ -141,9 +139,36 @@
     <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_disable_automount_open" selected="true"/>
     <!--1.7.8: Ensure GDM autorun-never is enabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_disable_autorun" selected="true"/>
+    <!--1.7.10: Ensure XDMCP is not enabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_gnome_gdm_disable_xdmcp" selected="true"/>
     <!--2.1.1: Ensure autofs services are not in use (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_service_autofs_disabled" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_package_autofs_removed" selected="true"/>
+    <!--2.1.2: Ensure avahi daemon services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_avahi_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_avahi-daemon_disabled" selected="true"/>
+    <!--2.1.3: Ensure dhcp server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_dhcp_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd_disabled" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd6_disabled" selected="true"/>
+    <!--2.1.4: Ensure dns server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_bind_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_named_disabled" selected="true"/>
+    <!--2.1.5: Ensure dnsmasq services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_dnsmasq_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dnsmasq_disabled" selected="true"/>
+    <!--2.1.6: Ensure ftp server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_vsftpd_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_vsftpd_disabled" selected="true"/>
+    <!--2.1.7: Ensure ldap server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_openldap-servers_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_slapd_disabled" selected="true"/>
+    <!--2.1.8: Ensure message access server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_dovecot_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dovecot_disabled" selected="true"/>
+    <!--2.1.9: Ensure network file system services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_nfs-kernel-server_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_nfs_disabled" selected="true"/>
     <!--2.1.10: Ensure nis server services are not in use (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_ypserv_removed" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_service_ypserv_disabled" selected="true"/>
@@ -176,37 +201,12 @@
     <!--2.1.19: Ensure xinetd services are not in use (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_xinetd_removed" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_service_xinetd_disabled" selected="true"/>
-    <!--2.1.2: Ensure avahi daemon services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_avahi_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_avahi-daemon_disabled" selected="true"/>
     <!--2.1.20: Ensure X window server services are not in use (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_xorg-x11-server-common_removed" selected="true"/>
     <!--2.1.21: Ensure mail transfer agent is configured for local-only mode (Automated)-->
     <set-value idref="xccdf_org.ssgproject.content_value_var_postfix_inet_interfaces">loopback-only</set-value>
     <select idref="xccdf_org.ssgproject.content_rule_has_nonlocal_mta" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_postfix_network_listening_disabled" selected="true"/>
-    <!--2.1.3: Ensure dhcp server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_dhcp_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd_disabled" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd6_disabled" selected="true"/>
-    <!--2.1.4: Ensure dns server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_bind_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_named_disabled" selected="true"/>
-    <!--2.1.5: Ensure dnsmasq services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_dnsmasq_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dnsmasq_disabled" selected="true"/>
-    <!--2.1.6: Ensure ftp server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_vsftpd_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_vsftpd_disabled" selected="true"/>
-    <!--2.1.7: Ensure ldap server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_openldap-servers_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_slapd_disabled" selected="true"/>
-    <!--2.1.8: Ensure message access server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_dovecot_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dovecot_disabled" selected="true"/>
-    <!--2.1.9: Ensure network file system services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_nfs-kernel-server_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_nfs_disabled" selected="true"/>
     <!--2.2.1: Ensure NIS Client is not installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_nis_removed" selected="true"/>
     <!--2.2.2: Ensure rsh client is not installed (Automated)-->
@@ -294,11 +294,6 @@
     <!--3.3.1: Ensure ip forwarding is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_forwarding" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_ip_forward" selected="true"/>
-    <!--3.3.10: Ensure tcp syn cookies is enabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_tcp_syncookies" selected="true"/>
-    <!--3.3.11: Ensure ipv6 router advertisements are not accepted (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_accept_ra" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_default_accept_ra" selected="true"/>
     <!--3.3.2: Ensure packet redirect sending is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_send_redirects" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_send_redirects" selected="true"/>
@@ -325,6 +320,11 @@
     <!--3.3.9: Ensure suspicious packets are logged (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_log_martians" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_log_martians" selected="true"/>
+    <!--3.3.10: Ensure tcp syn cookies is enabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_tcp_syncookies" selected="true"/>
+    <!--3.3.11: Ensure ipv6 router advertisements are not accepted (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_accept_ra" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_default_accept_ra" selected="true"/>
     <!--4.1.1: Ensure a single firewall configuration utility is in use (Automated)-->
     <set-value idref="xccdf_org.ssgproject.content_value_var_network_filtering_service">nftables</set-value>
     <select idref="xccdf_org.ssgproject.content_rule_firewall_single_service_active" selected="true"/>
@@ -343,9 +343,6 @@
     <select idref="xccdf_org.ssgproject.content_rule_set_ufw_default_rule" selected="true"/>
     <!--4.3.1: Ensure nftables is installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_nftables_installed" selected="true"/>
-    <!--4.3.10: Ensure nftables rules are permanent (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_nftables_master_config_file">/etc/nftables.conf</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_nftables_rules_permanent" selected="true"/>
     <!--4.3.2: Ensure ufw is uninstalled or disabled with nftables (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_ufw_removed" selected="true"/>
     <!--4.3.4: Ensure a nftables table exists (Automated)-->
@@ -365,6 +362,9 @@
     <select idref="xccdf_org.ssgproject.content_rule_nftables_ensure_default_deny_policy" selected="true"/>
     <!--4.3.9: Ensure nftables service is enabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_service_nftables_enabled" selected="true"/>
+    <!--4.3.10: Ensure nftables rules are permanent (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_nftables_master_config_file">/etc/nftables.conf</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_nftables_rules_permanent" selected="true"/>
     <!--4.4.1.1: Ensure iptables packages are installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_iptables-persistent_installed" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_package_iptables_installed" selected="true"/>
@@ -386,6 +386,25 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_sshd_config" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_sshd_config" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_config" selected="true"/>
+    <!--5.1.2: Ensure permissions on SSH private host key files are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_private_key" selected="true"/>
+    <!--5.1.3: Ensure permissions on SSH public host key files are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_pub_key" selected="true"/>
+    <!--5.1.4: Ensure sshd access is configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_limit_user_access" selected="true"/>
+    <!--5.1.5: Ensure sshd Banner is configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_enable_warning_banner_net" selected="true"/>
+    <!--5.1.6: Ensure sshd Ciphers are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_use_strong_ciphers" selected="true"/>
+    <!--5.1.7: Ensure sshd ClientAliveInterval and ClientAliveCountMax are configured (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_sshd_idle_timeout_value">300</set-value>
+    <set-value idref="xccdf_org.ssgproject.content_value_var_sshd_set_keepalive">3</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_idle_timeout" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_keepalive" selected="true"/>
+    <!--5.1.8: Ensure sshd DisableForwarding is enabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_forwarding" selected="true"/>
+    <!--5.1.9: Ensure sshd GSSAPIAuthentication is disabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_gssapi_auth" selected="true"/>
     <!--5.1.10: Ensure sshd HostbasedAuthentication is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_disable_host_auth" selected="true"/>
     <!--5.1.11: Ensure sshd IgnoreRhosts is enabled (Automated)-->
@@ -412,31 +431,12 @@
     <select idref="xccdf_org.ssgproject.content_rule_sshd_set_maxstartups" selected="true"/>
     <!--5.1.19: Ensure sshd PermitEmptyPasswords is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_empty_passwords" selected="true"/>
-    <!--5.1.2: Ensure permissions on SSH private host key files are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_private_key" selected="true"/>
     <!--5.1.20: Ensure sshd PermitRootLogin is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_root_login" selected="true"/>
     <!--5.1.21: Ensure sshd PermitUserEnvironment is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_do_not_permit_user_env" selected="true"/>
     <!--5.1.22: Ensure sshd UsePAM is enabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_enable_pam" selected="true"/>
-    <!--5.1.3: Ensure permissions on SSH public host key files are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_pub_key" selected="true"/>
-    <!--5.1.4: Ensure sshd access is configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_limit_user_access" selected="true"/>
-    <!--5.1.5: Ensure sshd Banner is configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_enable_warning_banner_net" selected="true"/>
-    <!--5.1.6: Ensure sshd Ciphers are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_use_strong_ciphers" selected="true"/>
-    <!--5.1.7: Ensure sshd ClientAliveInterval and ClientAliveCountMax are configured (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_sshd_idle_timeout_value">300</set-value>
-    <set-value idref="xccdf_org.ssgproject.content_value_var_sshd_set_keepalive">3</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_idle_timeout" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_keepalive" selected="true"/>
-    <!--5.1.8: Ensure sshd DisableForwarding is enabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_forwarding" selected="true"/>
-    <!--5.1.9: Ensure sshd GSSAPIAuthentication is disabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_gssapi_auth" selected="true"/>
     <!--5.2.1: Ensure sudo is installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_sudo_installed" selected="true"/>
     <!--5.2.2: Ensure sudo commands use pty (Automated)-->
@@ -678,41 +678,8 @@
     <select idref="xccdf_org.ssgproject.content_rule_auditd_data_retention_space_left_action" selected="true"/>
     <!--6.2.3.1: Ensure changes to system administration scope (sudoers) is collected (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_audit_rules_sysadmin_actions" selected="true"/>
-    <!--6.2.3.10: Ensure successful file system mounts are collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_media_export" selected="true"/>
-    <!--6.2.3.11: Ensure session initiation information is collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_session_events" selected="true"/>
-    <!--6.2.3.12: Ensure login and logout events are collected (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_accounts_passwords_pam_faillock_dir">/var/run/faillock</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_login_events_faillock" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_login_events_lastlog" selected="true"/>
-    <!--6.2.3.13: Ensure file deletion events by users are collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_rename" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_renameat" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_unlink" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_unlinkat" selected="true"/>
-    <!--6.2.3.14: Ensure events that modify the system's Mandatory Access Controls are collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_mac_modification_etc_apparmor" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_mac_modification_etc_apparmor_d" selected="true"/>
-    <!--6.2.3.15: Ensure successful and unsuccessful attempts to use the chcon command are collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_chcon" selected="true"/>
-    <!--6.2.3.16: Ensure successful and unsuccessful attempts to use the setfacl command are collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_setfacl" selected="true"/>
-    <!--6.2.3.17: Ensure successful and unsuccessful attempts to use the chacl command are collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_chacl" selected="true"/>
-    <!--6.2.3.18: Ensure successful and unsuccessful attempts to use the usermod command are collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_usermod" selected="true"/>
-    <!--6.2.3.19: Ensure kernel module loading unloading and modification is collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_delete" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_init" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_finit" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_create" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_query" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_kmod" selected="true"/>
     <!--6.2.3.2: Ensure actions as another user are always logged (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_audit_rules_suid_auid_privilege_function" selected="true"/>
-    <!--6.2.3.20: Ensure the audit configuration is immutable (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_immutable" selected="true"/>
     <!--6.2.3.3: Ensure events that modify the sudo log file are collected (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_audit_sudo_log_events" selected="true"/>
     <!--6.2.3.4: Ensure events that modify date and time information are collected (Automated)-->
@@ -753,10 +720,41 @@
     <select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_lsetxattr" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_removexattr" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_setxattr" selected="true"/>
+    <!--6.2.3.10: Ensure successful file system mounts are collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_media_export" selected="true"/>
+    <!--6.2.3.11: Ensure session initiation information is collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_session_events" selected="true"/>
+    <!--6.2.3.12: Ensure login and logout events are collected (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_accounts_passwords_pam_faillock_dir">/var/run/faillock</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_login_events_faillock" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_login_events_lastlog" selected="true"/>
+    <!--6.2.3.13: Ensure file deletion events by users are collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_rename" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_renameat" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_unlink" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_unlinkat" selected="true"/>
+    <!--6.2.3.14: Ensure events that modify the system's Mandatory Access Controls are collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_mac_modification_etc_apparmor" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_mac_modification_etc_apparmor_d" selected="true"/>
+    <!--6.2.3.15: Ensure successful and unsuccessful attempts to use the chcon command are collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_chcon" selected="true"/>
+    <!--6.2.3.16: Ensure successful and unsuccessful attempts to use the setfacl command are collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_setfacl" selected="true"/>
+    <!--6.2.3.17: Ensure successful and unsuccessful attempts to use the chacl command are collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_chacl" selected="true"/>
+    <!--6.2.3.18: Ensure successful and unsuccessful attempts to use the usermod command are collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_usermod" selected="true"/>
+    <!--6.2.3.19: Ensure kernel module loading unloading and modification is collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_delete" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_init" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_finit" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_create" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_query" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_kmod" selected="true"/>
+    <!--6.2.3.20: Ensure the audit configuration is immutable (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_immutable" selected="true"/>
     <!--6.2.4.1: Ensure audit log files mode is configured (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_var_log_audit" selected="true"/>
-    <!--6.2.4.10: Ensure audit tools group owner is configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupownership_audit_binaries" selected="true"/>
     <!--6.2.4.2: Ensure audit log files owner is configured (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_file_ownership_var_log_audit_stig" selected="true"/>
     <!--6.2.4.3: Ensure audit log files group owner is configured (Automated)-->
@@ -775,6 +773,8 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_audit_binaries" selected="true"/>
     <!--6.2.4.9: Ensure audit tools owner is configured (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_file_ownership_audit_binaries" selected="true"/>
+    <!--6.2.4.10: Ensure audit tools group owner is configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupownership_audit_binaries" selected="true"/>
     <!--6.3.1: Ensure AIDE is installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_aide_build_database" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_package_aide_installed" selected="true"/>
@@ -786,18 +786,6 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_passwd" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_passwd" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_passwd" selected="true"/>
-    <!--7.1.10: Ensure permissions on /etc/security/opasswd are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd_old" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd_old" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd_old" selected="true"/>
-    <!--7.1.11: Ensure world writable files and directories are secured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_unauthorized_world_writable" selected="true"/>
-    <!--7.1.12: Ensure no files or directories without an owner and a group exist (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_no_files_unowned_by_user" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_ungroupowned" selected="true"/>
     <!--7.1.2: Ensure permissions on /etc/passwd- are configured (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_backup_etc_passwd" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_backup_etc_passwd" selected="true"/>
@@ -830,17 +818,20 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_shells" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_shells" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_shells" selected="true"/>
+    <!--7.1.10: Ensure permissions on /etc/security/opasswd are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd_old" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd_old" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd_old" selected="true"/>
+    <!--7.1.11: Ensure world writable files and directories are secured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_unauthorized_world_writable" selected="true"/>
+    <!--7.1.12: Ensure no files or directories without an owner and a group exist (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_no_files_unowned_by_user" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_ungroupowned" selected="true"/>
     <!--7.2.1: Ensure accounts in /etc/passwd use shadowed passwords (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_accounts_password_all_shadowed" selected="true"/>
-    <!--7.2.10: Ensure local interactive user dot files access is configured (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_user_initialization_files_regex">^\.[\w\- ]+$</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_no_rsh_trust_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_no_forward_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_no_netrc_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_user_ownership" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_group_ownership" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_init_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_bash_history" selected="true"/>
     <!--7.2.2: Ensure /etc/shadow password fields are not empty (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_no_empty_passwords_etc_shadow" selected="true"/>
     <!--7.2.3: Ensure all groups in /etc/passwd exist in /etc/group (Automated)-->
@@ -860,5 +851,14 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_groupownership_home_directories" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_ownership_home_directories" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_home_directories" selected="true"/>
+    <!--7.2.10: Ensure local interactive user dot files access is configured (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_user_initialization_files_regex">^\.[\w\- ]+$</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_no_rsh_trust_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_no_forward_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_no_netrc_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_user_ownership" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_group_ownership" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_init_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_bash_history" selected="true"/>
   </Profile>
 </Tailoring>

--- a/tools/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_2/tailoring/cis_level2_workstation-tailoring.xml
+++ b/tools/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_2/tailoring/cis_level2_workstation-tailoring.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Tailoring xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_scap-workbench_tailoring_default">
   <benchmark href="/usr/share/usg-benchmarks/ubuntu2404_CIS_2"/>
-  <version time="2025-09-05T13:35:52+00:00">1</version>
+  <version time="2025-10-08T21:08:53+00:00">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level2_workstation_customized" extends="xccdf_org.ssgproject.content_profile_cis_level2_workstation">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 24.04 Level 2 Workstation Benchmark [CUSTOMIZED]</title>
     <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 24.04 LTS Benchmark, v1.0.0, released 08-26-2024.</description>
@@ -120,8 +120,6 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_issue_net" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_issue_net" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_issue_net" selected="true"/>
-    <!--1.7.10: Ensure XDMCP is not enabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_gnome_gdm_disable_xdmcp" selected="true"/>
     <!--1.7.2: Ensure GDM login banner is configured (Automated)-->
     <set-value idref="xccdf_org.ssgproject.content_value_login_banner_text">^Authorized[\s\n]+users[\s\n]+only\.[\s\n]+All[\s\n]+activity[\s\n]+may[\s\n]+be[\s\n]+monitored[\s\n]+and[\s\n]+reported\.$</set-value>
     <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_banner_enabled" selected="true"/>
@@ -139,9 +137,36 @@
     <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_disable_automount_open" selected="true"/>
     <!--1.7.8: Ensure GDM autorun-never is enabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_disable_autorun" selected="true"/>
+    <!--1.7.10: Ensure XDMCP is not enabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_gnome_gdm_disable_xdmcp" selected="true"/>
     <!--2.1.1: Ensure autofs services are not in use (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_service_autofs_disabled" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_package_autofs_removed" selected="true"/>
+    <!--2.1.2: Ensure avahi daemon services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_avahi_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_avahi-daemon_disabled" selected="true"/>
+    <!--2.1.3: Ensure dhcp server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_dhcp_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd_disabled" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd6_disabled" selected="true"/>
+    <!--2.1.4: Ensure dns server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_bind_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_named_disabled" selected="true"/>
+    <!--2.1.5: Ensure dnsmasq services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_dnsmasq_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dnsmasq_disabled" selected="true"/>
+    <!--2.1.6: Ensure ftp server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_vsftpd_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_vsftpd_disabled" selected="true"/>
+    <!--2.1.7: Ensure ldap server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_openldap-servers_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_slapd_disabled" selected="true"/>
+    <!--2.1.8: Ensure message access server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_dovecot_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dovecot_disabled" selected="true"/>
+    <!--2.1.9: Ensure network file system services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_nfs-kernel-server_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_nfs_disabled" selected="true"/>
     <!--2.1.10: Ensure nis server services are not in use (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_ypserv_removed" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_service_ypserv_disabled" selected="true"/>
@@ -174,35 +199,10 @@
     <!--2.1.19: Ensure xinetd services are not in use (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_xinetd_removed" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_service_xinetd_disabled" selected="true"/>
-    <!--2.1.2: Ensure avahi daemon services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_avahi_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_avahi-daemon_disabled" selected="true"/>
     <!--2.1.21: Ensure mail transfer agent is configured for local-only mode (Automated)-->
     <set-value idref="xccdf_org.ssgproject.content_value_var_postfix_inet_interfaces">loopback-only</set-value>
     <select idref="xccdf_org.ssgproject.content_rule_has_nonlocal_mta" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_postfix_network_listening_disabled" selected="true"/>
-    <!--2.1.3: Ensure dhcp server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_dhcp_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd_disabled" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd6_disabled" selected="true"/>
-    <!--2.1.4: Ensure dns server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_bind_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_named_disabled" selected="true"/>
-    <!--2.1.5: Ensure dnsmasq services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_dnsmasq_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dnsmasq_disabled" selected="true"/>
-    <!--2.1.6: Ensure ftp server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_vsftpd_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_vsftpd_disabled" selected="true"/>
-    <!--2.1.7: Ensure ldap server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_openldap-servers_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_slapd_disabled" selected="true"/>
-    <!--2.1.8: Ensure message access server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_dovecot_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dovecot_disabled" selected="true"/>
-    <!--2.1.9: Ensure network file system services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_nfs-kernel-server_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_nfs_disabled" selected="true"/>
     <!--2.2.1: Ensure NIS Client is not installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_nis_removed" selected="true"/>
     <!--2.2.2: Ensure rsh client is not installed (Automated)-->
@@ -288,11 +288,6 @@
     <!--3.3.1: Ensure ip forwarding is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_forwarding" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_ip_forward" selected="true"/>
-    <!--3.3.10: Ensure tcp syn cookies is enabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_tcp_syncookies" selected="true"/>
-    <!--3.3.11: Ensure ipv6 router advertisements are not accepted (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_accept_ra" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_default_accept_ra" selected="true"/>
     <!--3.3.2: Ensure packet redirect sending is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_send_redirects" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_send_redirects" selected="true"/>
@@ -319,6 +314,11 @@
     <!--3.3.9: Ensure suspicious packets are logged (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_log_martians" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_log_martians" selected="true"/>
+    <!--3.3.10: Ensure tcp syn cookies is enabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_tcp_syncookies" selected="true"/>
+    <!--3.3.11: Ensure ipv6 router advertisements are not accepted (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_accept_ra" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_default_accept_ra" selected="true"/>
     <!--4.1.1: Ensure a single firewall configuration utility is in use (Automated)-->
     <set-value idref="xccdf_org.ssgproject.content_value_var_network_filtering_service">nftables</set-value>
     <select idref="xccdf_org.ssgproject.content_rule_firewall_single_service_active" selected="true"/>
@@ -337,9 +337,6 @@
     <select idref="xccdf_org.ssgproject.content_rule_set_ufw_default_rule" selected="true"/>
     <!--4.3.1: Ensure nftables is installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_nftables_installed" selected="true"/>
-    <!--4.3.10: Ensure nftables rules are permanent (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_nftables_master_config_file">/etc/nftables.conf</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_nftables_rules_permanent" selected="true"/>
     <!--4.3.2: Ensure ufw is uninstalled or disabled with nftables (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_ufw_removed" selected="true"/>
     <!--4.3.4: Ensure a nftables table exists (Automated)-->
@@ -359,6 +356,9 @@
     <select idref="xccdf_org.ssgproject.content_rule_nftables_ensure_default_deny_policy" selected="true"/>
     <!--4.3.9: Ensure nftables service is enabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_service_nftables_enabled" selected="true"/>
+    <!--4.3.10: Ensure nftables rules are permanent (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_nftables_master_config_file">/etc/nftables.conf</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_nftables_rules_permanent" selected="true"/>
     <!--4.4.1.1: Ensure iptables packages are installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_iptables-persistent_installed" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_package_iptables_installed" selected="true"/>
@@ -380,6 +380,25 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_sshd_config" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_sshd_config" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_config" selected="true"/>
+    <!--5.1.2: Ensure permissions on SSH private host key files are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_private_key" selected="true"/>
+    <!--5.1.3: Ensure permissions on SSH public host key files are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_pub_key" selected="true"/>
+    <!--5.1.4: Ensure sshd access is configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_limit_user_access" selected="true"/>
+    <!--5.1.5: Ensure sshd Banner is configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_enable_warning_banner_net" selected="true"/>
+    <!--5.1.6: Ensure sshd Ciphers are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_use_strong_ciphers" selected="true"/>
+    <!--5.1.7: Ensure sshd ClientAliveInterval and ClientAliveCountMax are configured (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_sshd_idle_timeout_value">300</set-value>
+    <set-value idref="xccdf_org.ssgproject.content_value_var_sshd_set_keepalive">3</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_idle_timeout" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_keepalive" selected="true"/>
+    <!--5.1.8: Ensure sshd DisableForwarding is enabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_forwarding" selected="true"/>
+    <!--5.1.9: Ensure sshd GSSAPIAuthentication is disabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_gssapi_auth" selected="true"/>
     <!--5.1.10: Ensure sshd HostbasedAuthentication is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_disable_host_auth" selected="true"/>
     <!--5.1.11: Ensure sshd IgnoreRhosts is enabled (Automated)-->
@@ -406,31 +425,12 @@
     <select idref="xccdf_org.ssgproject.content_rule_sshd_set_maxstartups" selected="true"/>
     <!--5.1.19: Ensure sshd PermitEmptyPasswords is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_empty_passwords" selected="true"/>
-    <!--5.1.2: Ensure permissions on SSH private host key files are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_private_key" selected="true"/>
     <!--5.1.20: Ensure sshd PermitRootLogin is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_root_login" selected="true"/>
     <!--5.1.21: Ensure sshd PermitUserEnvironment is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_do_not_permit_user_env" selected="true"/>
     <!--5.1.22: Ensure sshd UsePAM is enabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_enable_pam" selected="true"/>
-    <!--5.1.3: Ensure permissions on SSH public host key files are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_pub_key" selected="true"/>
-    <!--5.1.4: Ensure sshd access is configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_limit_user_access" selected="true"/>
-    <!--5.1.5: Ensure sshd Banner is configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_enable_warning_banner_net" selected="true"/>
-    <!--5.1.6: Ensure sshd Ciphers are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_use_strong_ciphers" selected="true"/>
-    <!--5.1.7: Ensure sshd ClientAliveInterval and ClientAliveCountMax are configured (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_sshd_idle_timeout_value">300</set-value>
-    <set-value idref="xccdf_org.ssgproject.content_value_var_sshd_set_keepalive">3</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_idle_timeout" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_keepalive" selected="true"/>
-    <!--5.1.8: Ensure sshd DisableForwarding is enabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_forwarding" selected="true"/>
-    <!--5.1.9: Ensure sshd GSSAPIAuthentication is disabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_gssapi_auth" selected="true"/>
     <!--5.2.1: Ensure sudo is installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_sudo_installed" selected="true"/>
     <!--5.2.2: Ensure sudo commands use pty (Automated)-->
@@ -672,41 +672,8 @@
     <select idref="xccdf_org.ssgproject.content_rule_auditd_data_retention_space_left_action" selected="true"/>
     <!--6.2.3.1: Ensure changes to system administration scope (sudoers) is collected (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_audit_rules_sysadmin_actions" selected="true"/>
-    <!--6.2.3.10: Ensure successful file system mounts are collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_media_export" selected="true"/>
-    <!--6.2.3.11: Ensure session initiation information is collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_session_events" selected="true"/>
-    <!--6.2.3.12: Ensure login and logout events are collected (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_accounts_passwords_pam_faillock_dir">/var/run/faillock</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_login_events_faillock" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_login_events_lastlog" selected="true"/>
-    <!--6.2.3.13: Ensure file deletion events by users are collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_rename" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_renameat" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_unlink" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_unlinkat" selected="true"/>
-    <!--6.2.3.14: Ensure events that modify the system's Mandatory Access Controls are collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_mac_modification_etc_apparmor" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_mac_modification_etc_apparmor_d" selected="true"/>
-    <!--6.2.3.15: Ensure successful and unsuccessful attempts to use the chcon command are collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_chcon" selected="true"/>
-    <!--6.2.3.16: Ensure successful and unsuccessful attempts to use the setfacl command are collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_setfacl" selected="true"/>
-    <!--6.2.3.17: Ensure successful and unsuccessful attempts to use the chacl command are collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_chacl" selected="true"/>
-    <!--6.2.3.18: Ensure successful and unsuccessful attempts to use the usermod command are collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_usermod" selected="true"/>
-    <!--6.2.3.19: Ensure kernel module loading unloading and modification is collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_delete" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_init" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_finit" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_create" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_query" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_kmod" selected="true"/>
     <!--6.2.3.2: Ensure actions as another user are always logged (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_audit_rules_suid_auid_privilege_function" selected="true"/>
-    <!--6.2.3.20: Ensure the audit configuration is immutable (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_immutable" selected="true"/>
     <!--6.2.3.3: Ensure events that modify the sudo log file are collected (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_audit_sudo_log_events" selected="true"/>
     <!--6.2.3.4: Ensure events that modify date and time information are collected (Automated)-->
@@ -747,10 +714,41 @@
     <select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_lsetxattr" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_removexattr" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_setxattr" selected="true"/>
+    <!--6.2.3.10: Ensure successful file system mounts are collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_media_export" selected="true"/>
+    <!--6.2.3.11: Ensure session initiation information is collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_session_events" selected="true"/>
+    <!--6.2.3.12: Ensure login and logout events are collected (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_accounts_passwords_pam_faillock_dir">/var/run/faillock</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_login_events_faillock" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_login_events_lastlog" selected="true"/>
+    <!--6.2.3.13: Ensure file deletion events by users are collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_rename" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_renameat" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_unlink" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_unlinkat" selected="true"/>
+    <!--6.2.3.14: Ensure events that modify the system's Mandatory Access Controls are collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_mac_modification_etc_apparmor" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_mac_modification_etc_apparmor_d" selected="true"/>
+    <!--6.2.3.15: Ensure successful and unsuccessful attempts to use the chcon command are collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_chcon" selected="true"/>
+    <!--6.2.3.16: Ensure successful and unsuccessful attempts to use the setfacl command are collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_setfacl" selected="true"/>
+    <!--6.2.3.17: Ensure successful and unsuccessful attempts to use the chacl command are collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_chacl" selected="true"/>
+    <!--6.2.3.18: Ensure successful and unsuccessful attempts to use the usermod command are collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_usermod" selected="true"/>
+    <!--6.2.3.19: Ensure kernel module loading unloading and modification is collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_delete" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_init" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_finit" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_create" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_query" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_kmod" selected="true"/>
+    <!--6.2.3.20: Ensure the audit configuration is immutable (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_immutable" selected="true"/>
     <!--6.2.4.1: Ensure audit log files mode is configured (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_var_log_audit" selected="true"/>
-    <!--6.2.4.10: Ensure audit tools group owner is configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupownership_audit_binaries" selected="true"/>
     <!--6.2.4.2: Ensure audit log files owner is configured (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_file_ownership_var_log_audit_stig" selected="true"/>
     <!--6.2.4.3: Ensure audit log files group owner is configured (Automated)-->
@@ -769,6 +767,8 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_audit_binaries" selected="true"/>
     <!--6.2.4.9: Ensure audit tools owner is configured (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_file_ownership_audit_binaries" selected="true"/>
+    <!--6.2.4.10: Ensure audit tools group owner is configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupownership_audit_binaries" selected="true"/>
     <!--6.3.1: Ensure AIDE is installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_aide_build_database" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_package_aide_installed" selected="true"/>
@@ -780,18 +780,6 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_passwd" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_passwd" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_passwd" selected="true"/>
-    <!--7.1.10: Ensure permissions on /etc/security/opasswd are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd_old" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd_old" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd_old" selected="true"/>
-    <!--7.1.11: Ensure world writable files and directories are secured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_unauthorized_world_writable" selected="true"/>
-    <!--7.1.12: Ensure no files or directories without an owner and a group exist (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_no_files_unowned_by_user" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_ungroupowned" selected="true"/>
     <!--7.1.2: Ensure permissions on /etc/passwd- are configured (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_backup_etc_passwd" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_backup_etc_passwd" selected="true"/>
@@ -824,17 +812,20 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_shells" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_shells" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_shells" selected="true"/>
+    <!--7.1.10: Ensure permissions on /etc/security/opasswd are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd_old" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd_old" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd_old" selected="true"/>
+    <!--7.1.11: Ensure world writable files and directories are secured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_unauthorized_world_writable" selected="true"/>
+    <!--7.1.12: Ensure no files or directories without an owner and a group exist (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_no_files_unowned_by_user" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_ungroupowned" selected="true"/>
     <!--7.2.1: Ensure accounts in /etc/passwd use shadowed passwords (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_accounts_password_all_shadowed" selected="true"/>
-    <!--7.2.10: Ensure local interactive user dot files access is configured (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_user_initialization_files_regex">^\.[\w\- ]+$</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_no_rsh_trust_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_no_forward_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_no_netrc_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_user_ownership" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_group_ownership" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_init_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_bash_history" selected="true"/>
     <!--7.2.2: Ensure /etc/shadow password fields are not empty (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_no_empty_passwords_etc_shadow" selected="true"/>
     <!--7.2.3: Ensure all groups in /etc/passwd exist in /etc/group (Automated)-->
@@ -854,5 +845,14 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_groupownership_home_directories" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_ownership_home_directories" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_home_directories" selected="true"/>
+    <!--7.2.10: Ensure local interactive user dot files access is configured (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_user_initialization_files_regex">^\.[\w\- ]+$</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_no_rsh_trust_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_no_forward_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_no_netrc_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_user_ownership" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_group_ownership" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_init_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_bash_history" selected="true"/>
   </Profile>
 </Tailoring>

--- a/tools/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_3/tailoring/cis_level1_server-tailoring.xml
+++ b/tools/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_3/tailoring/cis_level1_server-tailoring.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Tailoring xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_scap-workbench_tailoring_default">
   <benchmark href="/usr/share/usg-benchmarks/ubuntu2404_CIS_3"/>
-  <version time="2025-09-05T13:35:53+00:00">1</version>
+  <version time="2025-10-08T21:08:53+00:00">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level1_server_customized" extends="xccdf_org.ssgproject.content_profile_cis_level1_server">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 24.04 Level 1 Server Benchmark [CUSTOMIZED]</title>
     <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 24.04 LTS Benchmark, v1.0.0, released 08-26-2024.</description>
@@ -104,8 +104,6 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_issue_net" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_issue_net" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_issue_net" selected="true"/>
-    <!--1.7.10: Ensure XDMCP is not enabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_gnome_gdm_disable_xdmcp" selected="true"/>
     <!--1.7.2: Ensure GDM login banner is configured (Automated)-->
     <set-value idref="xccdf_org.ssgproject.content_value_login_banner_text">^Authorized[\s\n]+users[\s\n]+only\.[\s\n]+All[\s\n]+activity[\s\n]+may[\s\n]+be[\s\n]+monitored[\s\n]+and[\s\n]+reported\.$</set-value>
     <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_banner_enabled" selected="true"/>
@@ -123,9 +121,36 @@
     <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_disable_automount_open" selected="true"/>
     <!--1.7.8: Ensure GDM autorun-never is enabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_disable_autorun" selected="true"/>
+    <!--1.7.10: Ensure XDMCP is not enabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_gnome_gdm_disable_xdmcp" selected="true"/>
     <!--2.1.1: Ensure autofs services are not in use (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_service_autofs_disabled" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_package_autofs_removed" selected="true"/>
+    <!--2.1.2: Ensure avahi daemon services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_avahi_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_avahi-daemon_disabled" selected="true"/>
+    <!--2.1.3: Ensure dhcp server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_dhcp_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd_disabled" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd6_disabled" selected="true"/>
+    <!--2.1.4: Ensure dns server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_bind_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_named_disabled" selected="true"/>
+    <!--2.1.5: Ensure dnsmasq services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_dnsmasq_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dnsmasq_disabled" selected="true"/>
+    <!--2.1.6: Ensure ftp server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_vsftpd_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_vsftpd_disabled" selected="true"/>
+    <!--2.1.7: Ensure ldap server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_openldap-servers_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_slapd_disabled" selected="true"/>
+    <!--2.1.8: Ensure message access server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_dovecot_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dovecot_disabled" selected="true"/>
+    <!--2.1.9: Ensure network file system services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_nfs-kernel-server_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_nfs_disabled" selected="true"/>
     <!--2.1.10: Ensure nis server services are not in use (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_ypserv_removed" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_service_ypserv_disabled" selected="true"/>
@@ -158,35 +183,10 @@
     <!--2.1.19: Ensure xinetd services are not in use (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_xinetd_removed" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_service_xinetd_disabled" selected="true"/>
-    <!--2.1.2: Ensure avahi daemon services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_avahi_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_avahi-daemon_disabled" selected="true"/>
     <!--2.1.21: Ensure mail transfer agent is configured for local-only mode (Automated)-->
     <set-value idref="xccdf_org.ssgproject.content_value_var_postfix_inet_interfaces">loopback-only</set-value>
     <select idref="xccdf_org.ssgproject.content_rule_has_nonlocal_mta" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_postfix_network_listening_disabled" selected="true"/>
-    <!--2.1.3: Ensure dhcp server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_dhcp_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd_disabled" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd6_disabled" selected="true"/>
-    <!--2.1.4: Ensure dns server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_bind_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_named_disabled" selected="true"/>
-    <!--2.1.5: Ensure dnsmasq services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_dnsmasq_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dnsmasq_disabled" selected="true"/>
-    <!--2.1.6: Ensure ftp server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_vsftpd_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_vsftpd_disabled" selected="true"/>
-    <!--2.1.7: Ensure ldap server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_openldap-servers_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_slapd_disabled" selected="true"/>
-    <!--2.1.8: Ensure message access server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_dovecot_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dovecot_disabled" selected="true"/>
-    <!--2.1.9: Ensure network file system services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_nfs-kernel-server_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_nfs_disabled" selected="true"/>
     <!--2.2.1: Ensure NIS Client is not installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_nis_removed" selected="true"/>
     <!--2.2.2: Ensure rsh client is not installed (Automated)-->
@@ -266,11 +266,6 @@
     <!--3.3.1: Ensure ip forwarding is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_forwarding" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_ip_forward" selected="true"/>
-    <!--3.3.10: Ensure tcp syn cookies is enabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_tcp_syncookies" selected="true"/>
-    <!--3.3.11: Ensure ipv6 router advertisements are not accepted (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_accept_ra" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_default_accept_ra" selected="true"/>
     <!--3.3.2: Ensure packet redirect sending is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_send_redirects" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_send_redirects" selected="true"/>
@@ -297,6 +292,11 @@
     <!--3.3.9: Ensure suspicious packets are logged (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_log_martians" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_log_martians" selected="true"/>
+    <!--3.3.10: Ensure tcp syn cookies is enabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_tcp_syncookies" selected="true"/>
+    <!--3.3.11: Ensure ipv6 router advertisements are not accepted (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_accept_ra" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_default_accept_ra" selected="true"/>
     <!--4.1.1: Ensure a single firewall configuration utility is in use (Automated)-->
     <set-value idref="xccdf_org.ssgproject.content_value_var_network_filtering_service">nftables</set-value>
     <select idref="xccdf_org.ssgproject.content_rule_firewall_single_service_active" selected="true"/>
@@ -315,9 +315,6 @@
     <select idref="xccdf_org.ssgproject.content_rule_set_ufw_default_rule" selected="true"/>
     <!--4.3.1: Ensure nftables is installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_nftables_installed" selected="true"/>
-    <!--4.3.10: Ensure nftables rules are permanent (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_nftables_master_config_file">/etc/nftables.conf</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_nftables_rules_permanent" selected="true"/>
     <!--4.3.2: Ensure ufw is uninstalled or disabled with nftables (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_ufw_removed" selected="true"/>
     <!--4.3.4: Ensure a nftables table exists (Automated)-->
@@ -337,6 +334,9 @@
     <select idref="xccdf_org.ssgproject.content_rule_nftables_ensure_default_deny_policy" selected="true"/>
     <!--4.3.9: Ensure nftables service is enabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_service_nftables_enabled" selected="true"/>
+    <!--4.3.10: Ensure nftables rules are permanent (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_nftables_master_config_file">/etc/nftables.conf</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_nftables_rules_permanent" selected="true"/>
     <!--4.4.1.1: Ensure iptables packages are installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_iptables-persistent_installed" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_package_iptables_installed" selected="true"/>
@@ -358,6 +358,21 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_sshd_config" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_sshd_config" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_config" selected="true"/>
+    <!--5.1.2: Ensure permissions on SSH private host key files are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_private_key" selected="true"/>
+    <!--5.1.3: Ensure permissions on SSH public host key files are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_pub_key" selected="true"/>
+    <!--5.1.4: Ensure sshd access is configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_limit_user_access" selected="true"/>
+    <!--5.1.5: Ensure sshd Banner is configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_enable_warning_banner_net" selected="true"/>
+    <!--5.1.6: Ensure sshd Ciphers are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_use_strong_ciphers" selected="true"/>
+    <!--5.1.7: Ensure sshd ClientAliveInterval and ClientAliveCountMax are configured (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_sshd_idle_timeout_value">300</set-value>
+    <set-value idref="xccdf_org.ssgproject.content_value_var_sshd_set_keepalive">3</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_idle_timeout" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_keepalive" selected="true"/>
     <!--5.1.10: Ensure sshd HostbasedAuthentication is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_disable_host_auth" selected="true"/>
     <!--5.1.11: Ensure sshd IgnoreRhosts is enabled (Automated)-->
@@ -384,27 +399,12 @@
     <select idref="xccdf_org.ssgproject.content_rule_sshd_set_maxstartups" selected="true"/>
     <!--5.1.19: Ensure sshd PermitEmptyPasswords is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_empty_passwords" selected="true"/>
-    <!--5.1.2: Ensure permissions on SSH private host key files are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_private_key" selected="true"/>
     <!--5.1.20: Ensure sshd PermitRootLogin is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_root_login" selected="true"/>
     <!--5.1.21: Ensure sshd PermitUserEnvironment is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_do_not_permit_user_env" selected="true"/>
     <!--5.1.22: Ensure sshd UsePAM is enabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_enable_pam" selected="true"/>
-    <!--5.1.3: Ensure permissions on SSH public host key files are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_pub_key" selected="true"/>
-    <!--5.1.4: Ensure sshd access is configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_limit_user_access" selected="true"/>
-    <!--5.1.5: Ensure sshd Banner is configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_enable_warning_banner_net" selected="true"/>
-    <!--5.1.6: Ensure sshd Ciphers are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_use_strong_ciphers" selected="true"/>
-    <!--5.1.7: Ensure sshd ClientAliveInterval and ClientAliveCountMax are configured (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_sshd_idle_timeout_value">300</set-value>
-    <set-value idref="xccdf_org.ssgproject.content_value_var_sshd_set_keepalive">3</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_idle_timeout" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_keepalive" selected="true"/>
     <!--5.2.1: Ensure sudo is installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_sudo_installed" selected="true"/>
     <!--5.2.2: Ensure sudo commands use pty (Automated)-->
@@ -614,18 +614,6 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_passwd" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_passwd" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_passwd" selected="true"/>
-    <!--7.1.10: Ensure permissions on /etc/security/opasswd are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd_old" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd_old" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd_old" selected="true"/>
-    <!--7.1.11: Ensure world writable files and directories are secured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_unauthorized_world_writable" selected="true"/>
-    <!--7.1.12: Ensure no files or directories without an owner and a group exist (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_no_files_unowned_by_user" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_ungroupowned" selected="true"/>
     <!--7.1.2: Ensure permissions on /etc/passwd- are configured (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_backup_etc_passwd" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_backup_etc_passwd" selected="true"/>
@@ -658,17 +646,20 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_shells" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_shells" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_shells" selected="true"/>
+    <!--7.1.10: Ensure permissions on /etc/security/opasswd are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd_old" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd_old" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd_old" selected="true"/>
+    <!--7.1.11: Ensure world writable files and directories are secured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_unauthorized_world_writable" selected="true"/>
+    <!--7.1.12: Ensure no files or directories without an owner and a group exist (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_no_files_unowned_by_user" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_ungroupowned" selected="true"/>
     <!--7.2.1: Ensure accounts in /etc/passwd use shadowed passwords (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_accounts_password_all_shadowed" selected="true"/>
-    <!--7.2.10: Ensure local interactive user dot files access is configured (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_user_initialization_files_regex">^\.[\w\- ]+$</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_no_rsh_trust_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_no_forward_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_no_netrc_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_user_ownership" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_group_ownership" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_init_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_bash_history" selected="true"/>
     <!--7.2.2: Ensure /etc/shadow password fields are not empty (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_no_empty_passwords_etc_shadow" selected="true"/>
     <!--7.2.3: Ensure all groups in /etc/passwd exist in /etc/group (Automated)-->
@@ -688,5 +679,14 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_groupownership_home_directories" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_ownership_home_directories" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_home_directories" selected="true"/>
+    <!--7.2.10: Ensure local interactive user dot files access is configured (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_user_initialization_files_regex">^\.[\w\- ]+$</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_no_rsh_trust_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_no_forward_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_no_netrc_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_user_ownership" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_group_ownership" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_init_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_bash_history" selected="true"/>
   </Profile>
 </Tailoring>

--- a/tools/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_3/tailoring/cis_level1_workstation-tailoring.xml
+++ b/tools/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_3/tailoring/cis_level1_workstation-tailoring.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Tailoring xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_scap-workbench_tailoring_default">
   <benchmark href="/usr/share/usg-benchmarks/ubuntu2404_CIS_3"/>
-  <version time="2025-09-05T13:35:53+00:00">1</version>
+  <version time="2025-10-08T21:08:54+00:00">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level1_workstation_customized" extends="xccdf_org.ssgproject.content_profile_cis_level1_workstation">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 24.04 Level 1 Workstation Benchmark [CUSTOMIZED]</title>
     <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 24.04 LTS Benchmark, v1.0.0, released 08-26-2024.</description>
@@ -102,8 +102,6 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_issue_net" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_issue_net" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_issue_net" selected="true"/>
-    <!--1.7.10: Ensure XDMCP is not enabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_gnome_gdm_disable_xdmcp" selected="true"/>
     <!--1.7.2: Ensure GDM login banner is configured (Automated)-->
     <set-value idref="xccdf_org.ssgproject.content_value_login_banner_text">^Authorized[\s\n]+users[\s\n]+only\.[\s\n]+All[\s\n]+activity[\s\n]+may[\s\n]+be[\s\n]+monitored[\s\n]+and[\s\n]+reported\.$</set-value>
     <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_banner_enabled" selected="true"/>
@@ -118,6 +116,30 @@
     <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_screensaver_lock_delay" selected="true"/>
     <!--1.7.8: Ensure GDM autorun-never is enabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_disable_autorun" selected="true"/>
+    <!--1.7.10: Ensure XDMCP is not enabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_gnome_gdm_disable_xdmcp" selected="true"/>
+    <!--2.1.3: Ensure dhcp server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_dhcp_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd_disabled" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd6_disabled" selected="true"/>
+    <!--2.1.4: Ensure dns server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_bind_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_named_disabled" selected="true"/>
+    <!--2.1.5: Ensure dnsmasq services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_dnsmasq_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dnsmasq_disabled" selected="true"/>
+    <!--2.1.6: Ensure ftp server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_vsftpd_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_vsftpd_disabled" selected="true"/>
+    <!--2.1.7: Ensure ldap server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_openldap-servers_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_slapd_disabled" selected="true"/>
+    <!--2.1.8: Ensure message access server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_dovecot_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dovecot_disabled" selected="true"/>
+    <!--2.1.9: Ensure network file system services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_nfs-kernel-server_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_nfs_disabled" selected="true"/>
     <!--2.1.10: Ensure nis server services are not in use (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_ypserv_removed" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_service_ypserv_disabled" selected="true"/>
@@ -151,28 +173,6 @@
     <set-value idref="xccdf_org.ssgproject.content_value_var_postfix_inet_interfaces">loopback-only</set-value>
     <select idref="xccdf_org.ssgproject.content_rule_has_nonlocal_mta" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_postfix_network_listening_disabled" selected="true"/>
-    <!--2.1.3: Ensure dhcp server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_dhcp_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd_disabled" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd6_disabled" selected="true"/>
-    <!--2.1.4: Ensure dns server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_bind_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_named_disabled" selected="true"/>
-    <!--2.1.5: Ensure dnsmasq services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_dnsmasq_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dnsmasq_disabled" selected="true"/>
-    <!--2.1.6: Ensure ftp server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_vsftpd_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_vsftpd_disabled" selected="true"/>
-    <!--2.1.7: Ensure ldap server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_openldap-servers_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_slapd_disabled" selected="true"/>
-    <!--2.1.8: Ensure message access server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_dovecot_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dovecot_disabled" selected="true"/>
-    <!--2.1.9: Ensure network file system services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_nfs-kernel-server_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_nfs_disabled" selected="true"/>
     <!--2.2.1: Ensure NIS Client is not installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_nis_removed" selected="true"/>
     <!--2.2.2: Ensure rsh client is not installed (Automated)-->
@@ -248,11 +248,6 @@
     <!--3.3.1: Ensure ip forwarding is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_forwarding" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_ip_forward" selected="true"/>
-    <!--3.3.10: Ensure tcp syn cookies is enabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_tcp_syncookies" selected="true"/>
-    <!--3.3.11: Ensure ipv6 router advertisements are not accepted (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_accept_ra" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_default_accept_ra" selected="true"/>
     <!--3.3.2: Ensure packet redirect sending is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_send_redirects" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_send_redirects" selected="true"/>
@@ -279,6 +274,11 @@
     <!--3.3.9: Ensure suspicious packets are logged (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_log_martians" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_log_martians" selected="true"/>
+    <!--3.3.10: Ensure tcp syn cookies is enabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_tcp_syncookies" selected="true"/>
+    <!--3.3.11: Ensure ipv6 router advertisements are not accepted (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_accept_ra" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_default_accept_ra" selected="true"/>
     <!--4.1.1: Ensure a single firewall configuration utility is in use (Automated)-->
     <set-value idref="xccdf_org.ssgproject.content_value_var_network_filtering_service">nftables</set-value>
     <select idref="xccdf_org.ssgproject.content_rule_firewall_single_service_active" selected="true"/>
@@ -297,9 +297,6 @@
     <select idref="xccdf_org.ssgproject.content_rule_set_ufw_default_rule" selected="true"/>
     <!--4.3.1: Ensure nftables is installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_nftables_installed" selected="true"/>
-    <!--4.3.10: Ensure nftables rules are permanent (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_nftables_master_config_file">/etc/nftables.conf</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_nftables_rules_permanent" selected="true"/>
     <!--4.3.2: Ensure ufw is uninstalled or disabled with nftables (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_ufw_removed" selected="true"/>
     <!--4.3.4: Ensure a nftables table exists (Automated)-->
@@ -319,6 +316,9 @@
     <select idref="xccdf_org.ssgproject.content_rule_nftables_ensure_default_deny_policy" selected="true"/>
     <!--4.3.9: Ensure nftables service is enabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_service_nftables_enabled" selected="true"/>
+    <!--4.3.10: Ensure nftables rules are permanent (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_nftables_master_config_file">/etc/nftables.conf</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_nftables_rules_permanent" selected="true"/>
     <!--4.4.1.1: Ensure iptables packages are installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_iptables-persistent_installed" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_package_iptables_installed" selected="true"/>
@@ -340,6 +340,25 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_sshd_config" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_sshd_config" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_config" selected="true"/>
+    <!--5.1.2: Ensure permissions on SSH private host key files are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_private_key" selected="true"/>
+    <!--5.1.3: Ensure permissions on SSH public host key files are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_pub_key" selected="true"/>
+    <!--5.1.4: Ensure sshd access is configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_limit_user_access" selected="true"/>
+    <!--5.1.5: Ensure sshd Banner is configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_enable_warning_banner_net" selected="true"/>
+    <!--5.1.6: Ensure sshd Ciphers are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_use_strong_ciphers" selected="true"/>
+    <!--5.1.7: Ensure sshd ClientAliveInterval and ClientAliveCountMax are configured (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_sshd_idle_timeout_value">300</set-value>
+    <set-value idref="xccdf_org.ssgproject.content_value_var_sshd_set_keepalive">3</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_idle_timeout" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_keepalive" selected="true"/>
+    <!--5.1.8: Ensure sshd DisableForwarding is enabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_forwarding" selected="true"/>
+    <!--5.1.9: Ensure sshd GSSAPIAuthentication is disabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_gssapi_auth" selected="true"/>
     <!--5.1.10: Ensure sshd HostbasedAuthentication is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_disable_host_auth" selected="true"/>
     <!--5.1.11: Ensure sshd IgnoreRhosts is enabled (Automated)-->
@@ -366,31 +385,12 @@
     <select idref="xccdf_org.ssgproject.content_rule_sshd_set_maxstartups" selected="true"/>
     <!--5.1.19: Ensure sshd PermitEmptyPasswords is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_empty_passwords" selected="true"/>
-    <!--5.1.2: Ensure permissions on SSH private host key files are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_private_key" selected="true"/>
     <!--5.1.20: Ensure sshd PermitRootLogin is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_root_login" selected="true"/>
     <!--5.1.21: Ensure sshd PermitUserEnvironment is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_do_not_permit_user_env" selected="true"/>
     <!--5.1.22: Ensure sshd UsePAM is enabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_enable_pam" selected="true"/>
-    <!--5.1.3: Ensure permissions on SSH public host key files are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_pub_key" selected="true"/>
-    <!--5.1.4: Ensure sshd access is configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_limit_user_access" selected="true"/>
-    <!--5.1.5: Ensure sshd Banner is configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_enable_warning_banner_net" selected="true"/>
-    <!--5.1.6: Ensure sshd Ciphers are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_use_strong_ciphers" selected="true"/>
-    <!--5.1.7: Ensure sshd ClientAliveInterval and ClientAliveCountMax are configured (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_sshd_idle_timeout_value">300</set-value>
-    <set-value idref="xccdf_org.ssgproject.content_value_var_sshd_set_keepalive">3</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_idle_timeout" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_keepalive" selected="true"/>
-    <!--5.1.8: Ensure sshd DisableForwarding is enabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_forwarding" selected="true"/>
-    <!--5.1.9: Ensure sshd GSSAPIAuthentication is disabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_gssapi_auth" selected="true"/>
     <!--5.2.1: Ensure sudo is installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_sudo_installed" selected="true"/>
     <!--5.2.2: Ensure sudo commands use pty (Automated)-->
@@ -600,18 +600,6 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_passwd" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_passwd" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_passwd" selected="true"/>
-    <!--7.1.10: Ensure permissions on /etc/security/opasswd are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd_old" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd_old" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd_old" selected="true"/>
-    <!--7.1.11: Ensure world writable files and directories are secured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_unauthorized_world_writable" selected="true"/>
-    <!--7.1.12: Ensure no files or directories without an owner and a group exist (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_no_files_unowned_by_user" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_ungroupowned" selected="true"/>
     <!--7.1.2: Ensure permissions on /etc/passwd- are configured (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_backup_etc_passwd" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_backup_etc_passwd" selected="true"/>
@@ -644,17 +632,20 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_shells" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_shells" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_shells" selected="true"/>
+    <!--7.1.10: Ensure permissions on /etc/security/opasswd are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd_old" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd_old" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd_old" selected="true"/>
+    <!--7.1.11: Ensure world writable files and directories are secured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_unauthorized_world_writable" selected="true"/>
+    <!--7.1.12: Ensure no files or directories without an owner and a group exist (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_no_files_unowned_by_user" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_ungroupowned" selected="true"/>
     <!--7.2.1: Ensure accounts in /etc/passwd use shadowed passwords (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_accounts_password_all_shadowed" selected="true"/>
-    <!--7.2.10: Ensure local interactive user dot files access is configured (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_user_initialization_files_regex">^\.[\w\- ]+$</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_no_rsh_trust_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_no_forward_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_no_netrc_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_user_ownership" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_group_ownership" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_init_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_bash_history" selected="true"/>
     <!--7.2.2: Ensure /etc/shadow password fields are not empty (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_no_empty_passwords_etc_shadow" selected="true"/>
     <!--7.2.3: Ensure all groups in /etc/passwd exist in /etc/group (Automated)-->
@@ -674,5 +665,14 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_groupownership_home_directories" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_ownership_home_directories" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_home_directories" selected="true"/>
+    <!--7.2.10: Ensure local interactive user dot files access is configured (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_user_initialization_files_regex">^\.[\w\- ]+$</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_no_rsh_trust_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_no_forward_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_no_netrc_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_user_ownership" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_group_ownership" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_init_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_bash_history" selected="true"/>
   </Profile>
 </Tailoring>

--- a/tools/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_3/tailoring/cis_level2_server-tailoring.xml
+++ b/tools/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_3/tailoring/cis_level2_server-tailoring.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Tailoring xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_scap-workbench_tailoring_default">
   <benchmark href="/usr/share/usg-benchmarks/ubuntu2404_CIS_3"/>
-  <version time="2025-09-05T13:35:53+00:00">1</version>
+  <version time="2025-10-08T21:08:54+00:00">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level2_server_customized" extends="xccdf_org.ssgproject.content_profile_cis_level2_server">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 24.04 Level 2 Server Benchmark [CUSTOMIZED]</title>
     <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 24.04 LTS Benchmark, v1.0.0, released 08-26-2024.</description>
@@ -122,8 +122,6 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_issue_net" selected="true"/>
     <!--1.7.1: Ensure GDM is removed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_gdm_removed" selected="true"/>
-    <!--1.7.10: Ensure XDMCP is not enabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_gnome_gdm_disable_xdmcp" selected="true"/>
     <!--1.7.2: Ensure GDM login banner is configured (Automated)-->
     <set-value idref="xccdf_org.ssgproject.content_value_login_banner_text">^Authorized[\s\n]+users[\s\n]+only\.[\s\n]+All[\s\n]+activity[\s\n]+may[\s\n]+be[\s\n]+monitored[\s\n]+and[\s\n]+reported\.$</set-value>
     <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_banner_enabled" selected="true"/>
@@ -141,9 +139,36 @@
     <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_disable_automount_open" selected="true"/>
     <!--1.7.8: Ensure GDM autorun-never is enabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_dconf_gnome_disable_autorun" selected="true"/>
+    <!--1.7.10: Ensure XDMCP is not enabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_gnome_gdm_disable_xdmcp" selected="true"/>
     <!--2.1.1: Ensure autofs services are not in use (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_service_autofs_disabled" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_package_autofs_removed" selected="true"/>
+    <!--2.1.2: Ensure avahi daemon services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_avahi_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_avahi-daemon_disabled" selected="true"/>
+    <!--2.1.3: Ensure dhcp server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_dhcp_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd_disabled" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd6_disabled" selected="true"/>
+    <!--2.1.4: Ensure dns server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_bind_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_named_disabled" selected="true"/>
+    <!--2.1.5: Ensure dnsmasq services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_dnsmasq_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dnsmasq_disabled" selected="true"/>
+    <!--2.1.6: Ensure ftp server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_vsftpd_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_vsftpd_disabled" selected="true"/>
+    <!--2.1.7: Ensure ldap server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_openldap-servers_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_slapd_disabled" selected="true"/>
+    <!--2.1.8: Ensure message access server services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_dovecot_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_dovecot_disabled" selected="true"/>
+    <!--2.1.9: Ensure network file system services are not in use (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_package_nfs-kernel-server_removed" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_service_nfs_disabled" selected="true"/>
     <!--2.1.10: Ensure nis server services are not in use (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_ypserv_removed" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_service_ypserv_disabled" selected="true"/>
@@ -176,37 +201,12 @@
     <!--2.1.19: Ensure xinetd services are not in use (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_xinetd_removed" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_service_xinetd_disabled" selected="true"/>
-    <!--2.1.2: Ensure avahi daemon services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_avahi_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_avahi-daemon_disabled" selected="true"/>
     <!--2.1.20: Ensure X window server services are not in use (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_xorg-x11-server-common_removed" selected="true"/>
     <!--2.1.21: Ensure mail transfer agent is configured for local-only mode (Automated)-->
     <set-value idref="xccdf_org.ssgproject.content_value_var_postfix_inet_interfaces">loopback-only</set-value>
     <select idref="xccdf_org.ssgproject.content_rule_has_nonlocal_mta" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_postfix_network_listening_disabled" selected="true"/>
-    <!--2.1.3: Ensure dhcp server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_dhcp_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd_disabled" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dhcpd6_disabled" selected="true"/>
-    <!--2.1.4: Ensure dns server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_bind_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_named_disabled" selected="true"/>
-    <!--2.1.5: Ensure dnsmasq services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_dnsmasq_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dnsmasq_disabled" selected="true"/>
-    <!--2.1.6: Ensure ftp server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_vsftpd_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_vsftpd_disabled" selected="true"/>
-    <!--2.1.7: Ensure ldap server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_openldap-servers_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_slapd_disabled" selected="true"/>
-    <!--2.1.8: Ensure message access server services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_dovecot_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_dovecot_disabled" selected="true"/>
-    <!--2.1.9: Ensure network file system services are not in use (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_package_nfs-kernel-server_removed" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_service_nfs_disabled" selected="true"/>
     <!--2.2.1: Ensure NIS Client is not installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_nis_removed" selected="true"/>
     <!--2.2.2: Ensure rsh client is not installed (Automated)-->
@@ -294,11 +294,6 @@
     <!--3.3.1: Ensure ip forwarding is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_forwarding" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_ip_forward" selected="true"/>
-    <!--3.3.10: Ensure tcp syn cookies is enabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_tcp_syncookies" selected="true"/>
-    <!--3.3.11: Ensure ipv6 router advertisements are not accepted (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_accept_ra" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_default_accept_ra" selected="true"/>
     <!--3.3.2: Ensure packet redirect sending is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_send_redirects" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_send_redirects" selected="true"/>
@@ -325,6 +320,11 @@
     <!--3.3.9: Ensure suspicious packets are logged (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_log_martians" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_log_martians" selected="true"/>
+    <!--3.3.10: Ensure tcp syn cookies is enabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_tcp_syncookies" selected="true"/>
+    <!--3.3.11: Ensure ipv6 router advertisements are not accepted (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_accept_ra" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_default_accept_ra" selected="true"/>
     <!--4.1.1: Ensure a single firewall configuration utility is in use (Automated)-->
     <set-value idref="xccdf_org.ssgproject.content_value_var_network_filtering_service">nftables</set-value>
     <select idref="xccdf_org.ssgproject.content_rule_firewall_single_service_active" selected="true"/>
@@ -343,9 +343,6 @@
     <select idref="xccdf_org.ssgproject.content_rule_set_ufw_default_rule" selected="true"/>
     <!--4.3.1: Ensure nftables is installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_nftables_installed" selected="true"/>
-    <!--4.3.10: Ensure nftables rules are permanent (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_nftables_master_config_file">/etc/nftables.conf</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_nftables_rules_permanent" selected="true"/>
     <!--4.3.2: Ensure ufw is uninstalled or disabled with nftables (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_ufw_removed" selected="true"/>
     <!--4.3.4: Ensure a nftables table exists (Automated)-->
@@ -365,6 +362,9 @@
     <select idref="xccdf_org.ssgproject.content_rule_nftables_ensure_default_deny_policy" selected="true"/>
     <!--4.3.9: Ensure nftables service is enabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_service_nftables_enabled" selected="true"/>
+    <!--4.3.10: Ensure nftables rules are permanent (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_nftables_master_config_file">/etc/nftables.conf</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_nftables_rules_permanent" selected="true"/>
     <!--4.4.1.1: Ensure iptables packages are installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_iptables-persistent_installed" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_package_iptables_installed" selected="true"/>
@@ -386,6 +386,25 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_sshd_config" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_sshd_config" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_config" selected="true"/>
+    <!--5.1.2: Ensure permissions on SSH private host key files are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_private_key" selected="true"/>
+    <!--5.1.3: Ensure permissions on SSH public host key files are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_pub_key" selected="true"/>
+    <!--5.1.4: Ensure sshd access is configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_limit_user_access" selected="true"/>
+    <!--5.1.5: Ensure sshd Banner is configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_enable_warning_banner_net" selected="true"/>
+    <!--5.1.6: Ensure sshd Ciphers are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_use_strong_ciphers" selected="true"/>
+    <!--5.1.7: Ensure sshd ClientAliveInterval and ClientAliveCountMax are configured (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_sshd_idle_timeout_value">300</set-value>
+    <set-value idref="xccdf_org.ssgproject.content_value_var_sshd_set_keepalive">3</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_idle_timeout" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_keepalive" selected="true"/>
+    <!--5.1.8: Ensure sshd DisableForwarding is enabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_forwarding" selected="true"/>
+    <!--5.1.9: Ensure sshd GSSAPIAuthentication is disabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_gssapi_auth" selected="true"/>
     <!--5.1.10: Ensure sshd HostbasedAuthentication is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_disable_host_auth" selected="true"/>
     <!--5.1.11: Ensure sshd IgnoreRhosts is enabled (Automated)-->
@@ -412,31 +431,12 @@
     <select idref="xccdf_org.ssgproject.content_rule_sshd_set_maxstartups" selected="true"/>
     <!--5.1.19: Ensure sshd PermitEmptyPasswords is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_empty_passwords" selected="true"/>
-    <!--5.1.2: Ensure permissions on SSH private host key files are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_private_key" selected="true"/>
     <!--5.1.20: Ensure sshd PermitRootLogin is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_root_login" selected="true"/>
     <!--5.1.21: Ensure sshd PermitUserEnvironment is disabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_do_not_permit_user_env" selected="true"/>
     <!--5.1.22: Ensure sshd UsePAM is enabled (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_sshd_enable_pam" selected="true"/>
-    <!--5.1.3: Ensure permissions on SSH public host key files are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_pub_key" selected="true"/>
-    <!--5.1.4: Ensure sshd access is configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_limit_user_access" selected="true"/>
-    <!--5.1.5: Ensure sshd Banner is configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_enable_warning_banner_net" selected="true"/>
-    <!--5.1.6: Ensure sshd Ciphers are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_use_strong_ciphers" selected="true"/>
-    <!--5.1.7: Ensure sshd ClientAliveInterval and ClientAliveCountMax are configured (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_sshd_idle_timeout_value">300</set-value>
-    <set-value idref="xccdf_org.ssgproject.content_value_var_sshd_set_keepalive">3</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_idle_timeout" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_set_keepalive" selected="true"/>
-    <!--5.1.8: Ensure sshd DisableForwarding is enabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_forwarding" selected="true"/>
-    <!--5.1.9: Ensure sshd GSSAPIAuthentication is disabled (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_sshd_disable_gssapi_auth" selected="true"/>
     <!--5.2.1: Ensure sudo is installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_package_sudo_installed" selected="true"/>
     <!--5.2.2: Ensure sudo commands use pty (Automated)-->
@@ -678,41 +678,8 @@
     <select idref="xccdf_org.ssgproject.content_rule_auditd_data_retention_space_left_action" selected="true"/>
     <!--6.2.3.1: Ensure changes to system administration scope (sudoers) is collected (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_audit_rules_sysadmin_actions" selected="true"/>
-    <!--6.2.3.10: Ensure successful file system mounts are collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_media_export" selected="true"/>
-    <!--6.2.3.11: Ensure session initiation information is collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_session_events" selected="true"/>
-    <!--6.2.3.12: Ensure login and logout events are collected (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_accounts_passwords_pam_faillock_dir">/var/run/faillock</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_login_events_faillock" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_login_events_lastlog" selected="true"/>
-    <!--6.2.3.13: Ensure file deletion events by users are collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_rename" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_renameat" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_unlink" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_unlinkat" selected="true"/>
-    <!--6.2.3.14: Ensure events that modify the system's Mandatory Access Controls are collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_mac_modification_etc_apparmor" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_mac_modification_etc_apparmor_d" selected="true"/>
-    <!--6.2.3.15: Ensure successful and unsuccessful attempts to use the chcon command are collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_chcon" selected="true"/>
-    <!--6.2.3.16: Ensure successful and unsuccessful attempts to use the setfacl command are collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_setfacl" selected="true"/>
-    <!--6.2.3.17: Ensure successful and unsuccessful attempts to use the chacl command are collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_chacl" selected="true"/>
-    <!--6.2.3.18: Ensure successful and unsuccessful attempts to use the usermod command are collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_usermod" selected="true"/>
-    <!--6.2.3.19: Ensure kernel module loading unloading and modification is collected (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_delete" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_init" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_finit" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_create" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_query" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_kmod" selected="true"/>
     <!--6.2.3.2: Ensure actions as another user are always logged (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_audit_rules_suid_auid_privilege_function" selected="true"/>
-    <!--6.2.3.20: Ensure the audit configuration is immutable (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_immutable" selected="true"/>
     <!--6.2.3.3: Ensure events that modify the sudo log file are collected (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_audit_sudo_log_events" selected="true"/>
     <!--6.2.3.4: Ensure events that modify date and time information are collected (Automated)-->
@@ -753,10 +720,41 @@
     <select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_lsetxattr" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_removexattr" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_setxattr" selected="true"/>
+    <!--6.2.3.10: Ensure successful file system mounts are collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_media_export" selected="true"/>
+    <!--6.2.3.11: Ensure session initiation information is collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_session_events" selected="true"/>
+    <!--6.2.3.12: Ensure login and logout events are collected (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_accounts_passwords_pam_faillock_dir">/var/run/faillock</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_login_events_faillock" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_login_events_lastlog" selected="true"/>
+    <!--6.2.3.13: Ensure file deletion events by users are collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_rename" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_renameat" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_unlink" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_unlinkat" selected="true"/>
+    <!--6.2.3.14: Ensure events that modify the system's Mandatory Access Controls are collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_mac_modification_etc_apparmor" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_mac_modification_etc_apparmor_d" selected="true"/>
+    <!--6.2.3.15: Ensure successful and unsuccessful attempts to use the chcon command are collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_chcon" selected="true"/>
+    <!--6.2.3.16: Ensure successful and unsuccessful attempts to use the setfacl command are collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_setfacl" selected="true"/>
+    <!--6.2.3.17: Ensure successful and unsuccessful attempts to use the chacl command are collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_chacl" selected="true"/>
+    <!--6.2.3.18: Ensure successful and unsuccessful attempts to use the usermod command are collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_usermod" selected="true"/>
+    <!--6.2.3.19: Ensure kernel module loading unloading and modification is collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_delete" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_init" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_finit" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_create" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_query" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_kmod" selected="true"/>
+    <!--6.2.3.20: Ensure the audit configuration is immutable (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_immutable" selected="true"/>
     <!--6.2.4.1: Ensure audit log files mode is configured (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_var_log_audit" selected="true"/>
-    <!--6.2.4.10: Ensure audit tools group owner is configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupownership_audit_binaries" selected="true"/>
     <!--6.2.4.2: Ensure audit log files owner is configured (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_file_ownership_var_log_audit_stig" selected="true"/>
     <!--6.2.4.3: Ensure audit log files group owner is configured (Automated)-->
@@ -775,6 +773,8 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_audit_binaries" selected="true"/>
     <!--6.2.4.9: Ensure audit tools owner is configured (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_file_ownership_audit_binaries" selected="true"/>
+    <!--6.2.4.10: Ensure audit tools group owner is configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupownership_audit_binaries" selected="true"/>
     <!--6.3.1: Ensure AIDE is installed (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_aide_build_database" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_package_aide_installed" selected="true"/>
@@ -786,18 +786,6 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_passwd" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_passwd" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_passwd" selected="true"/>
-    <!--7.1.10: Ensure permissions on /etc/security/opasswd are configured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd_old" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd_old" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd_old" selected="true"/>
-    <!--7.1.11: Ensure world writable files and directories are secured (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_unauthorized_world_writable" selected="true"/>
-    <!--7.1.12: Ensure no files or directories without an owner and a group exist (Automated)-->
-    <select idref="xccdf_org.ssgproject.content_rule_no_files_unowned_by_user" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_ungroupowned" selected="true"/>
     <!--7.1.2: Ensure permissions on /etc/passwd- are configured (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_backup_etc_passwd" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_backup_etc_passwd" selected="true"/>
@@ -830,17 +818,20 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_shells" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_shells" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_shells" selected="true"/>
+    <!--7.1.10: Ensure permissions on /etc/security/opasswd are configured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_owner_etc_security_opasswd_old" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_groupowner_etc_security_opasswd_old" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_etc_security_opasswd_old" selected="true"/>
+    <!--7.1.11: Ensure world writable files and directories are secured (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_unauthorized_world_writable" selected="true"/>
+    <!--7.1.12: Ensure no files or directories without an owner and a group exist (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_no_files_unowned_by_user" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permissions_ungroupowned" selected="true"/>
     <!--7.2.1: Ensure accounts in /etc/passwd use shadowed passwords (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_accounts_password_all_shadowed" selected="true"/>
-    <!--7.2.10: Ensure local interactive user dot files access is configured (Automated)-->
-    <set-value idref="xccdf_org.ssgproject.content_value_var_user_initialization_files_regex">^\.[\w\- ]+$</set-value>
-    <select idref="xccdf_org.ssgproject.content_rule_no_rsh_trust_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_no_forward_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_no_netrc_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_user_ownership" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_group_ownership" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_init_files" selected="true"/>
-    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_bash_history" selected="true"/>
     <!--7.2.2: Ensure /etc/shadow password fields are not empty (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_no_empty_passwords_etc_shadow" selected="true"/>
     <!--7.2.3: Ensure all groups in /etc/passwd exist in /etc/group (Automated)-->
@@ -860,5 +851,14 @@
     <select idref="xccdf_org.ssgproject.content_rule_file_groupownership_home_directories" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_ownership_home_directories" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_rule_file_permissions_home_directories" selected="true"/>
+    <!--7.2.10: Ensure local interactive user dot files access is configured (Automated)-->
+    <set-value idref="xccdf_org.ssgproject.content_value_var_user_initialization_files_regex">^\.[\w\- ]+$</set-value>
+    <select idref="xccdf_org.ssgproject.content_rule_no_rsh_trust_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_no_forward_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_no_netrc_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_user_ownership" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_accounts_user_dot_group_ownership" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_init_files" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_file_permission_user_bash_history" selected="true"/>
   </Profile>
 </Tailoring>

--- a/tools/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_STIG_1/tailoring/stig-tailoring.xml
+++ b/tools/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_STIG_1/tailoring/stig-tailoring.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Tailoring xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_scap-workbench_tailoring_default">
   <benchmark href="/usr/share/usg-benchmarks/ubuntu2404_STIG_1"/>
-  <version time="2025-09-05T13:35:55+00:00">1</version>
+  <version time="2025-10-08T21:08:55+00:00">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_stig_customized" extends="xccdf_org.ssgproject.content_profile_stig">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">DISA-STIG Benchmark [CUSTOMIZED]</title>
     <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the DISA-STIG v.1, rel.1, released 2025-01-28.</description>

--- a/tools/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_STIG_2/tailoring/stig-tailoring.xml
+++ b/tools/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_STIG_2/tailoring/stig-tailoring.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Tailoring xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_scap-workbench_tailoring_default">
   <benchmark href="/usr/share/usg-benchmarks/ubuntu2404_STIG_2"/>
-  <version time="2025-09-05T13:35:55+00:00">1</version>
+  <version time="2025-10-08T21:08:56+00:00">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_stig_customized" extends="xccdf_org.ssgproject.content_profile_stig">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">DISA-STIG Benchmark [CUSTOMIZED]</title>
     <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the DISA-STIG v.1, rel.1, released 2025-01-28.</description>


### PR DESCRIPTION
- Disable rule sorting in `generate_tailoring_file` and keep order as is defined in control files and profile files
- Update test data
