### PR TITLE
Improve fix command logic

### DIFF
--- a/debian/tests/usg-cli-e2e
+++ b/debian/tests/usg-cli-e2e
@@ -108,7 +108,20 @@ test_cmd "usg info"  0  "Using the default tailoring file" ""
 rm /etc/usg/default-tailoring.xml
 
 # Audit with tailoring file, should be 1 pass, 1 fail
+rm -f /var/lib/usg/*
 test_cmd "usg audit -t t1.xml"  0  "^Fail:.*1$"  ""
+# Ensure default outputs exist
+test_cmd "test -s /var/lib/usg/usg-report-*.html"  0  "" ""
+test_cmd "test -s /var/lib/usg/usg-results-*.xml"  0  "" ""
+# Ensure non-default outputs exist
+rm -f /var/lib/usg/* report.html results.xml
+test_cmd "usg audit -t t1.xml --html-file report.html --results-file results.xml --debug --oval-results"  0  "^Fail:.*1$"  ""
+test_cmd "test -s report.html"  0  "" ""
+test_cmd "test -s results.xml"  0  "" ""
+test_cmd "test -s /var/lib/usg/usg-log-*log"  0  "" ""
+test_cmd "test -s /var/lib/usg/ssg-ubuntu????-oval.xml.result-*.xml"  0  "" ""
+test_cmd "test -s /var/lib/usg/ssg-ubuntu????-cpe-oval.xml.result-*.xml"  0  "" ""
+
 
 # Fix with tailoring file, only failed rules
 rm -f /var/lib/usg/xccdf*sh
@@ -121,11 +134,21 @@ test_cmd "usg audit -t t1.xml"  0  "^Fail:.*0$"  ""
 
 
 # Fix with tailoring file, all rules
-rm -f /var/lib/usg/xccdf*sh
+rm -f /var/lib/usg/*
 test_cmd "usg fix -t t1.xml"  0  "fix command completed" ""
 # test both rules are in remediation script
 test_cmd "grep -c BEGIN /var/lib/usg/xccdf*sh"  0  "^2$"  ""
-
+# Ensure default outputs exist
+test_cmd "test -s /var/lib/usg/usg-report-*.html"  0  "" ""
+test_cmd "test -s /var/lib/usg/usg-results-*.xml"  0  "" ""
+# Ensure non-default outputs exist
+rm -f /var/lib/usg/* report.html results.xml
+test_cmd "usg fix -t t1.xml --html-file report.html --results-file results.xml --debug --oval-results"  0  "fix command completed"  ""
+test_cmd "test -s report.html"  0  "" ""
+test_cmd "test -s results.xml"  0  "" ""
+test_cmd "test -s /var/lib/usg/usg-log-*log"  0  "" ""
+test_cmd "test -s /var/lib/usg/ssg-ubuntu????-oval.xml.result-*.xml"  0  "" ""
+test_cmd "test -s /var/lib/usg/ssg-ubuntu????-cpe-oval.xml.result-*.xml"  0  "" ""
 
 
 # test that the legacy usg fallback runs ok and fails due to missing benchmark bundle

--- a/src/usg/cli.py
+++ b/src/usg/cli.py
@@ -336,7 +336,16 @@ def command_fix(usg: USG, args: argparse.Namespace) -> None:
     logger.debug("Starting command_fix")
     usg_profile = get_usg_profile_from_args(usg, args)
     print("Running audit and remediation script...")
-    _ = usg.fix(usg_profile, only_failed=args.only_failed)
+
+    _, output_files = usg.audit(
+        usg_profile, debug=args.debug, oval_results=args.oval_results
+    )
+    audit_results_file = None
+    if args.only_failed:
+        audit_results_file = output_files.get_by_type("audit_results").path
+
+    _ = usg.fix(usg_profile, audit_results_file=audit_results_file)
+
     print(
         "USG fix command completed.\n"
         "A system reboot is required to complete the fix process.\n"

--- a/src/usg/config.py
+++ b/src/usg/config.py
@@ -92,7 +92,7 @@ def get_artifact_destination_path(
 
     Args:
         config: config parser
-        option: option name in [opensca_backend] section ofconfig
+        option: option name in [openscap_backend] section of config
         timestamp: timestamp (YYYYMMDD.HHMM)
         cac_profile: profile id (e.g. cis_level1_server)
         product: product name (e.g. ubuntu2404)
@@ -131,6 +131,8 @@ def override_config_with_cli_args(
     map_cli_paths_to_config = {
         "audit.html_file": "openscap_backend.audit_report",
         "audit.results_file": "openscap_backend.audit_results",
+        "fix.html_file": "openscap_backend.audit_report",
+        "fix.results_file": "openscap_backend.audit_results",
         "generate-fix.output": "openscap_backend.fix_script",
     }
     for cli_arg, cfg_opt in map_cli_paths_to_config.items():

--- a/src/usg/usg.py
+++ b/src/usg/usg.py
@@ -372,12 +372,16 @@ class USG:
 
         return artifacts
 
-    def fix(self, profile: Profile, only_failed: bool = False) -> BackendArtifacts:
+    def fix(
+            self,
+            profile: Profile,
+            audit_results_file: Path | None = None
+            ) -> BackendArtifacts:
         """Prepare environment and backend and remediates profile.
 
         Args:
             profile: Profile object
-            only_failed: if True, only remediate failed rules
+            audit_results_file: if given, only remediate failed rules in the audit
 
         Returns:
             BackendArtifacts: output files from the fix operation
@@ -392,13 +396,8 @@ class USG:
         work_dir = tempfile.mkdtemp(dir=constants.STATE_DIR, prefix="fix_")
         backend = self._init_openscap_backend(benchmark, work_dir)
         try:
-            results, artifacts = backend.audit(
-                profile.profile_id, profile.tailoring_file
-            )
-
             # pass audit results to fix operation to only remediated failed rules
-            if only_failed:
-                audit_results_file = artifacts.get_by_type("audit_results").path
+            if audit_results_file is not None:
                 logger.info(
                     f"Only remediating failed rules from audit results file "
                     f"{audit_results_file.name}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -75,7 +75,7 @@ def patch_usg_and_cli(tmp_path_factory, dummy_benchmarks):
                 f"Benchmark={profile.benchmark_id}"
             )
             output_files = BackendArtifacts()
-            output_files.add_artifact("results", "test_results_contents")
+            output_files.add_artifact("audit_results", "test_results_contents")
             return AuditResults(), output_files
 
         def generate_fix(self, profile) -> BackendArtifacts:
@@ -88,12 +88,13 @@ def patch_usg_and_cli(tmp_path_factory, dummy_benchmarks):
             output_files.add_artifact("fix_script", "test_fix_contents")
             return output_files
 
-        def fix(self, profile, only_failed=False) -> BackendArtifacts:
+        def fix(self, profile, audit_results_file=None) -> BackendArtifacts:
+            fn = audit_results_file.name if audit_results_file else "None"
             print(
                 f"Fix called with profile_id={profile.profile_id},"
                 f"tailoring_file={profile.tailoring_file}."
                 f"Benchmark={profile.benchmark_id}"
-                f"only_failed={only_failed}"
+                f"audit_results_file={fn}"
             )
             output_files = BackendArtifacts()
             output_files.add_artifact("fix_script", "test_fix_contents")
@@ -235,8 +236,8 @@ def test_usg_init_error(patch_usg_and_cli, monkeypatch, capsys):
         (["generate-tailoring"], None, "following arguments are required:", 2),
         (["generate-tailoring", "cis_level1_server"], None, "following arguments are required:", 2),
         # fix command with extra arguments
-        (["fix", "cis_level1_server"], "only_failed=False", None, None),
-        (["fix", "cis_level1_server", "--only-failed"], "only_failed=True", None, None),
+        (["fix", "cis_level1_server"], "audit_results_file=None", None, None),
+        (["fix", "cis_level1_server", "--only-failed"], "audit_results_file=test_results_content", None, None),
     ],
 )
 def test_cli_invocation(

--- a/tests/test_usg.py
+++ b/tests/test_usg.py
@@ -17,6 +17,7 @@
 
 import datetime
 import configparser
+from pathlib import Path
 
 import pytest
 from pytest import MonkeyPatch
@@ -311,25 +312,21 @@ def test_fix(patch_usg, dummy_benchmarks, capsys):
     profile = usg.get_profile("cis_level1_server", "ubuntu2404")
     _ = usg.fix(profile)
     stdout, _ = capsys.readouterr()
-    assert stdout == (
-        "audit called with profile_id=cis_level1_server, "
-        "tailoring_file=None, debug=False, oval_results=False\n"
+    assert stdout.strip() == (
         "fix called with profile_id=cis_level1_server, "
-        "tailoring_file=None, audit_results_file=None\n"
+        "tailoring_file=None, audit_results_file=None"
     )
 
 
-def test_fix_only_failed(patch_usg, dummy_benchmarks, capsys):
+def test_fix_audit_results_file(patch_usg, dummy_benchmarks, capsys):
     # test that fix only remediates failed rules
     usg = USG()
     profile = usg.get_profile("cis_level1_server", "ubuntu2404")
-    _ = usg.fix(profile, only_failed=True)
+    _ = usg.fix(profile, audit_results_file=Path("/path/to/test_audit_results_file.xml"))
     stdout, stderr = capsys.readouterr()
-    assert stdout == (
-        "audit called with profile_id=cis_level1_server, "
-        "tailoring_file=None, debug=False, oval_results=False\n"
+    assert stdout.strip() == (
         "fix called with profile_id=cis_level1_server, "
-        "tailoring_file=None, audit_results_file=test_backend_results_file.xml\n"
+        "tailoring_file=None, audit_results_file=test_audit_results_file.xml"
     )
 
 
@@ -337,7 +334,7 @@ def test_fix_correct_artifact_names(patch_usg, dummy_config, dummy_benchmarks, c
     # test that fix creates the correct artifact name and moves it to the correct path
     usg = USG(dummy_config)
     profile = usg.get_profile("cis_level1_server", "ubuntu2404")
-    artifacts = usg.fix(profile, only_failed=True)
+    artifacts = usg.fix(profile)
     expected_name = "test-fix-cis_level1_server-20250715.1200.sh"
     assert artifacts.get_by_type("fix_script").path.name == expected_name
 


### PR DESCRIPTION
For compatibility with legacy usg, the fix command needs to always run an audit beforehand, even when fixing all rules.

This change does two things:
- Fix current implementation which fails to write the output files of the pre-remediation audit
- Move the audit out of usg.fix and into cli domain to avoid enforcing the audit logic in the core module

Tests were adapted and extended to test for output files.