### PR TITLE
Minor fixes for autopkgtest, completions, and var naming

### DIFF
--- a/debian/tests/usg-cli-e2e
+++ b/debian/tests/usg-cli-e2e
@@ -87,8 +87,9 @@ done
 
 # ensure known aliases resolve correctly
 if grep -w "stig" <<<"${all_profiles[@]}"; then
-    test_cmd "usg info stig | grep '^Profile.* stig-v1r1' " 0 "stig-v1r1"
-    test_cmd "usg info disa_stig | grep '^Profile.* stig-v1r1' " 0 "stig-v1r1"
+    initial_id=$(usg list -a -m | awk -F: '/_STIG_1:/ {print $1}')
+    test_cmd "usg info stig | grep '^Profile.* $initial_id$' " 0 "$initial_id"
+    test_cmd "usg info disa_stig | grep '^Profile.* $initial_id$' " 0 "$initial_id"
 fi
 test_cmd "usg info cis_level1_server | grep '^Profile.* cis_level1_server-v1.0.0' " 0 "cis_level1_server-v1.0.0"
 

--- a/debian/usg.bash-completion
+++ b/debian/usg.bash-completion
@@ -69,11 +69,6 @@ _usg_completions() {
                 COMPREPLY=()
                 return
                 ;;
-            --benchmark-version)
-                # only suggest latest
-                COMPREPLY=($(compgen -W "latest" -- $cur))
-                return
-                ;;
         esac
         case "$cmd" in
             list)
@@ -88,7 +83,7 @@ _usg_completions() {
                 COMPREPLY=($(compgen -W "$opts" -- "$cur"))
                 ;;
             audit)
-                opts="--help --benchmark-version --html-file \
+                opts="--help --html-file \
                       --results-file --oval-results --debug"
                 opts="$(add_profile_and_or_tailoring "$opts")"
                 opts=$(filter_existing_opts "$opts")
@@ -96,20 +91,20 @@ _usg_completions() {
                 return
                 ;;
             fix)
-                opts="--help --benchmark-version --html-file \
+                opts="--help --html-file \
                       --results-file --oval-results --only-failed --debug"
                 opts="$(add_profile_and_or_tailoring "$opts")"
                 opts=$(filter_existing_opts "$opts")
                 COMPREPLY=($(compgen -W "$opts" -- "$cur"))
                 ;;
             generate-fix)
-                opts="--help --benchmark-version --debug --output"
+                opts="--help --debug --output"
                 opts="$(add_profile_and_or_tailoring "$opts")"
                 opts=$(filter_existing_opts "$opts")
                 COMPREPLY=($(compgen -W "$opts" -- "$cur"))
                 ;;
             generate-tailoring)
-                opts="--help --benchmark-version"
+                opts="--help"
                 opts=$(filter_existing_opts "$opts")
                 num_pos=$(count_num_positional_args)
                 if [[ "${num_pos}" -eq 3 ]]; then

--- a/src/usg/models.py
+++ b/src/usg/models.py
@@ -337,10 +337,10 @@ class TailoringFile:
 
 
     @staticmethod
-    def _map_benchmark_id_from_legacy(benchmark_href: str, profile_id: str) -> str:
-        """Map benchmark id from legacy href attribute and profile id.
+    def _map_benchmark_channel_id_from_legacy(benchmark_href: str, profile_id: str) -> str:
+        """Map benchmark release channel id from legacy href attribute and profile id.
 
-        Maps the legacy href to the new ID scheme (e.g. ubuntu2404_CIS_1)
+        Maps the legacy href to the new channel id (e.g. ubuntu2404_CIS_1)
         by extracting the tailoring_file version and the
         product name from the href itself.
         The benchmark type can be inferred from the profile.
@@ -351,14 +351,14 @@ class TailoringFile:
             profile_id: profile id attribute from tailoring file
 
         Returns:
-            (benchmark_id, profile_id)
+            (channel_id, profile_id)
 
         Raises:
             TailoringFileError: parsing issues
 
         """
         logger.debug(
-                f"Extracting benchmark_id from legacy href "
+                f"Extracting channel_id from legacy href "
                 f"{benchmark_href} and profile {profile_id}"
                 )
         # example match: (1, 'ubuntu2404')
@@ -382,21 +382,21 @@ class TailoringFile:
                 f"Cannot infer benchmark type from profile {profile_id}"
             )
 
-        benchmark_id = f"{product}_{benchmark_type}_{channel_number}"
+        channel_id = f"{product}_{benchmark_type}_{channel_number}"
         logger.debug(
-            f"Extracted benchmark id from legacy tailoring file: {benchmark_id}"
+            f"Extracted channel id from legacy tailoring file: {channel_id}"
         )
-        return benchmark_id
+        return channel_id
 
     @staticmethod
     def _parse_tailoring_scap(tailoring_file_contents: str) -> tuple[str, str, str]:
-        """Parse scap tailoring file contents and returns benchmark and profile IDs.
+        """Parse scap tailoring file contents and returns channel and profile IDs.
 
         Args:
             tailoring_file_contents: string contents of tailoring file
 
         Returns:
-            (benchmark_id, tailoring_profile_id, base_profile_name)
+            (channel_id, tailoring_profile_id, base_profile_name)
 
         Raises:
             TailoringFileError: parsing issues
@@ -450,12 +450,12 @@ class TailoringFile:
 
         if "/usr/share/usg-benchmarks" in benchmark_href:
             # new href (e.g. /usr/share/usg-benchmarks/ubuntu2404_CIS_1,
-            # benchmark_id is equal to ubuntu2404_CIS_1)
-            benchmark_id = Path(benchmark_href).name
+            # channel_id is equal to ubuntu2404_CIS_1)
+            channel_id = Path(benchmark_href).name
         elif "/usr/share/ubuntu-scap-security-guide" in benchmark_href:
             # legacy href (e.v. /usr/share/ubuntu-scap-security-guide/...)
             logger.info("Using legacy tailoring file.")
-            benchmark_id = TailoringFile._map_benchmark_id_from_legacy(
+            channel_id = TailoringFile._map_benchmark_channel_id_from_legacy(
                     benchmark_href, profile_id
                     )
         else:
@@ -466,4 +466,4 @@ class TailoringFile:
         # remove xccdf prefixes
         profile_id = profile_id.replace("xccdf_org.ssgproject.content_profile_", "")
         base_profile_id = base_profile_id.replace("xccdf_org.ssgproject.content_profile_", "")
-        return benchmark_id, profile_id, base_profile_id
+        return channel_id, profile_id, base_profile_id


### PR DESCRIPTION
Minor fixes:
- Remove stale version flag from bash completion
- Fix hardcoded profile id in autopkgtest
- Fix var naming in internal function to match new schema (benchmark_id -> channel_id)