### PR TITLE
Version 22.04.15

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-ubuntu-security-guides-enhanced (22.04.14) jammy; urgency=medium
+ubuntu-security-guides-enhanced (22.04.15) jammy; urgency=medium
 
   [Alan Moore]
   * Add new profiles for benchmark CIS v2.0.0
@@ -14,7 +14,7 @@ ubuntu-security-guides-enhanced (22.04.14) jammy; urgency=medium
   * Add bash completion for USG
   * Add autopkgtest script
 
- -- Miha Purg <miha.purg@canonical.com>  Tue, 21 Oct 2025 16:44:27 +0200
+ -- Miha Purg <miha.purg@canonical.com>  Wed, 22 Oct 2025 15:44:24 +0200
 
 ubuntu-security-guides-enhanced (22.04.13) jammy; urgency=medium
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 # pyproject.toml (PEP 621) is not supported in setuptools < 61
 [metadata]
 name = usg
-version = 22.04.14
+version = 22.04.15
 
 [options]
 packages = find:

--- a/tools/release_metadata/jammy_cis_benchmarks.yml
+++ b/tools/release_metadata/jammy_cis_benchmarks.yml
@@ -7,7 +7,7 @@ benchmark_releases:
   parent_tag: jammy-cis-1.14
   release_channel: 2
   cac_commit: 5300eca5cc88b4c1f5c710bf9d87d866cd22ccd9
-  usg_version: 22.04.14
+  usg_version: 22.04.15
   benchmark_data:
     version: v2.0.0
     profiles:
@@ -16,13 +16,13 @@ benchmark_releases:
       cis_level1_workstation: {}
       cis_level2_workstation: {}
     description: ComplianceAsCode implementation of CIS Ubuntu 22.04 LTS v2.0.0 benchmark.
-    release_notes_url: https://github.com/canonical/ubuntu-security-guide/pull/100
+    release_notes_url: https://github.com/canonical/ubuntu-security-guide/pull/105
     reference_url: https://www.cisecurity.org/benchmark/ubuntu_linux/
 - cac_tag: jammy-cis-1.14
   parent_tag: jammy-cis-1.13
   release_channel: 1
   cac_commit: 7fb4a79e7dfc13f7d2b941ddfb0d915bef269970
-  usg_version: 22.04.14
+  usg_version: 22.04.15
   benchmark_data:
     version: v1.0.0
     profiles:
@@ -32,7 +32,7 @@ benchmark_releases:
       cis_level1_workstation: {}
       cis_level2_workstation: {}
     description: ComplianceAsCode implementation of CIS Ubuntu 22.04 LTS v1.0.0 benchmark.
-    release_notes_url: https://github.com/canonical/ubuntu-security-guide/pull/100
+    release_notes_url: https://github.com/canonical/ubuntu-security-guide/pull/105
     reference_url: https://www.cisecurity.org/benchmark/ubuntu_linux/
 - cac_tag: jammy-cis-1.13
   parent_tag: jammy-cis-1.12

--- a/tools/release_metadata/jammy_stig_benchmarks.yml
+++ b/tools/release_metadata/jammy_stig_benchmarks.yml
@@ -7,13 +7,13 @@ benchmark_releases:
   parent_tag: jammy-stig-1.6
   release_channel: 1
   cac_commit: a3a49e112f3d7c0bdbf837d985bf77b192bf47cc
-  usg_version: 22.04.14
+  usg_version: 22.04.15
   benchmark_data:
     version: V2R3
     profiles:
       stig: {}
     description: ComplianceAsCode implementation of STIG Ubuntu 22.04 LTS V2R3 benchmark.
-    release_notes_url: https://github.com/canonical/ubuntu-security-guide/pull/100
+    release_notes_url: https://github.com/canonical/ubuntu-security-guide/pull/105
     reference_url: https://public.cyber.mil/stigs/downloads/
 - cac_tag: jammy-stig-1.6
   parent_tag: jammy-stig-1.5


### PR DESCRIPTION
#### Release info
- New profiles for Ubuntu 22.04 CIS v2.0.0 benchmark
- USG rewrite in python (see https://github.com/canonical/ubuntu-security-guide/pull/76)

#### Changelog

  [Alan Moore]
  * Add new profiles for benchmark CIS v2.0.0

  [Miha Purg]
  * Rewrite USG in python:
        - Add support for coexisting multiple versions of benchmark profiles
        - Add functionality to list and display information about profiles
        - Add functionality for fixing only failed rules (--only-failed)
        - Improve tests, configuration, logging
  * Rewrite build tooling to process multiple benchmarks
  * Switch to benchmarks package usg-benchmarks and drop debian-alternatives
  * Add bash completion for USG
  * Add autopkgtest script
