### PR TITLE
Version 24.04.6

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,24 @@
+ubuntu-security-guides-enhanced (24.04.6) noble; urgency=medium
+
+  * Rewrite USG in Python:
+    - Add support for multiple versions of benchmark profiles
+    - Add funcionality to list and display informatino about profiles
+    - Add functionality for fixing only failing rules (--only-failed)
+    - Improve tests, configuration, logging
+  * Rewrite build tooling to process multiple benchmarks
+  * Switch to benchmarks package usg-benchmarks and drop debian-alternatives
+  * Add bash completion for USG
+  * Add autopkgtest script
+  * Update CaC content:
+    - Add support for distributed sshd configuration (CIS v1.0.0)
+    - Add timeout for acquiring the APT lock to mitigate issues with
+      failing rules due to unattended-upgrades running in the background
+    - Improve set_loopback_traffic
+    - Fix audit_rules_privileged_commands_kmod check to allow old auditd
+      watch format (STIG V1R1)
+
+ -- Miha Purg <miha.purg@canonical.com>  Mon, 01 Dec 2025 15:55:43 +0100
+
 ubuntu-security-guides-enhanced (24.04.5) noble; urgency=medium
 
   * CaC content:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "usg"
-version = "24.04.5"
+version = "24.04.6"
 requires-python = ">=3.10"
 authors = [
     { name = "Miha Purg" },

--- a/templates/doc/man8/usg.md
+++ b/templates/doc/man8/usg.md
@@ -14,7 +14,7 @@ usg - Audit and remediation tool for security benchmarks compliance automatizati
 
 **usg** **audit** [**`--tailoring-file` filename** | **profile**]
 
-**usg** **fix** [**`--tailoring-file` filename** | **profile**]
+**usg** **fix** [**`--only-failed`**] [**`--tailoring-file` filename** | **profile**]
 
 **usg** **generate-fix** [**`--output` filename**] [**`--tailoring-file` filename** | **profile**]
 
@@ -59,6 +59,9 @@ Running usg without any command line parameters will display usage.
 **`--tailoring-file`**
 : Sets the path to the tailoring-file, which contains a set of rules-selectors and value-customization elements, effectively letting the user customize the rules which will be applied. If that option is used, then the profile parameter is ignored! This option can be used for both commands. Check the **Tailoring Files** section for more info on them.
 
+**`--only-failed`**
+: Use this option with **usg fix** to remediate only the rules which fail the initial audit, instead of remediating all rules.
+
 # EXAMPLES
 1. list all profiles, including deprecated versions
 
@@ -84,13 +87,17 @@ Running usg without any command line parameters will display usage.
 
     `# usg generate-tailoring cis_level2_workstation /etc/usg/default-tailoring.xml`
 
-7. audit and remediate system using the default tailoring file for the system
+7. audit and remediate system
 
     `# usg fix`
 
+8. audit the system and remediate only the failed rules
+
+    `# usg fix --only-failed`
+
 
 # TAILORING FILES
-usg rules are associated with **usg profiles** (and their benchmark counterparts) on datastream files used by OpenSCAP, which also contain the parameters used by the rules.
+usg rules are associated with **usg profiles** (and their benchmark counterparts) in datastream files used by OpenSCAP, which also contain the parameters used by the rules.
 The datastream files, however, are quite verbose and complicated and usg hides the complexity of dealing with them. **Tailoring files** is the way to customize profiles with usg.
 
 A tailoring file is a XML file which contains the list of rules that are used in auditing and fixing with their corresponding parameters.
@@ -105,7 +112,7 @@ This element sets if a given **usg rule** will be audited (and/or fixed, dependi
 <xccdf:select idref="sshd_set_loglevel_info_or_verbose" selected="false"/>
 ```
 
-## the xccdf:set-value element
+## The xccdf:set-value element
 This element sets a variable associated with a given usg rule. The variable will change the way the rule executes in a specific way for that rule. So, as an example, if the administrator wants to customize his tailoring file to change the *var\_sshd\_set\_loglevel* variable to the value 'VERBOSE', its associated *xccdf:set-value* element must be set as below:
 
 ```
@@ -115,18 +122,13 @@ This element sets a variable associated with a given usg rule. The variable will
 For a list of rules and their descriptions, see the **usg-rules** man page.
 For a list of variables and their descriptions, see the **usg-variables** man page.
 
-## Tailoring files and Benchmark rules
+## Obtaining tailoring files
 The **usg-benchmarks** package provides tailoring files for each version of each profile in the *tailoring* subdirectory inside its installation directory.
+
 Those tailoring files are essentially a copy of their respective profiles, containing their respective rules, so an admin can can disable specific ones.
+The *usg rules* in the tailoring files are grouped according to the benchmark rules they belong to, with the comments pointing to the benchmark rule identifier and its name.
 
-The provided tailoring files also group the *usg rules* according to the benchmark rules they belong to, with the comments pointing to the benchmark rule identifier and its name.
-
-**We strongly recommend using the command generate-tailoring to get a copy of the tailoring file and customize that copy, instead of modifying the original ones**
-
-Note that the *generate-tailoring* command uses the aforementioned original tailoring files to generate new ones.
-
-The *usg* tool depends on the *usg-benchmarks* package to be able to execute its operations. The *usg* tool quits with an error message if the package is missing.
-
+Use the command **generate-tailoring** to get a copy of the tailoring file for a specific profile.
 
 # TAILORING FILES COMPATIBILITY
 Tailoring files are tied to a major version of a profile and are incompatible with other versions.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -159,10 +159,12 @@ def test_check_perms_not_owned(tmp_path, monkeypatch, caplog):
 
 @pytest.mark.parametrize("uid,gid,expected_return", [
     [0, 0, True],
-    [0, os.getgid(), True],
-    [os.getuid(), os.getgid(), True],
+    [0, 1000, True],
+    [1000, 0, True],
+    [1000, 1000, True],
     [0, 12345, False],
-    [12345, 0, False]
+    [12345, 0, False],
+    [12345, 12345, False]
     ])
 def test_has_good_ownership(uid, gid, expected_return):
     class FakeStatResult(object):

--- a/tools/release_metadata/noble_cis_benchmarks.yml
+++ b/tools/release_metadata/noble_cis_benchmarks.yml
@@ -2,21 +2,34 @@ general:
   benchmark_type: CIS
   product: ubuntu2404
   product_long: Ubuntu 24.04 LTS (Noble Numbat)
-
 benchmark_releases:
-  - cac_tag: noble-cis-1.5
-    parent_tag: 
-    release_channel: 1
-    cac_commit: e40871066ec2edfce046b53241f0e02d4a184ea5
-    usg_version: 24.04.5
-    benchmark_data:
-      version: v1.0.0
-      profiles:
-          cis_level1_server: {}
-          cis_level2_server: {}
-          cis_level1_workstation: {}
-          cis_level2_workstation: {}
-      description: |-
-          ComplianceAsCode implementation of CIS Ubuntu 24.04 LTS v1.0.0 benchmark.
-      release_notes_url: https://github.com/canonical/ubuntu-security-guide/pull/72
-      reference_url: https://www.cisecurity.org/benchmark/ubuntu_linux/
+- cac_tag: noble-cis-1.6
+  parent_tag: noble-cis-1.5
+  release_channel: 1
+  cac_commit: 799fa94e4a9c151b83854fdaa2735b551a0eb214
+  usg_version: 24.04.6
+  benchmark_data:
+    version: v1.0.0
+    profiles:
+      cis_level1_server: {}
+      cis_level2_server: {}
+      cis_level1_workstation: {}
+      cis_level2_workstation: {}
+    description: ComplianceAsCode implementation of CIS Ubuntu 24.04 LTS v1.0.0 benchmark.
+    release_notes_url: https://github.com/canonical/ubuntu-security-guide/pull/110
+    reference_url: https://www.cisecurity.org/benchmark/ubuntu_linux/
+- cac_tag: noble-cis-1.5
+  parent_tag: null
+  release_channel: 1
+  cac_commit: e40871066ec2edfce046b53241f0e02d4a184ea5
+  usg_version: 24.04.5
+  benchmark_data:
+    version: v1.0.0
+    profiles:
+      cis_level1_server: {}
+      cis_level2_server: {}
+      cis_level1_workstation: {}
+      cis_level2_workstation: {}
+    description: ComplianceAsCode implementation of CIS Ubuntu 24.04 LTS v1.0.0 benchmark.
+    release_notes_url: https://github.com/canonical/ubuntu-security-guide/pull/72
+    reference_url: https://www.cisecurity.org/benchmark/ubuntu_linux/

--- a/tools/release_metadata/noble_stig_benchmarks.yml
+++ b/tools/release_metadata/noble_stig_benchmarks.yml
@@ -2,18 +2,28 @@ general:
   benchmark_type: STIG
   product: ubuntu2404
   product_long: Ubuntu 24.04 LTS (Noble Numbat)
-
 benchmark_releases:
-  - cac_tag: noble-stig-1.0
-    parent_tag: 
-    release_channel: 1
-    cac_commit: e40871066ec2edfce046b53241f0e02d4a184ea5
-    usg_version: 24.04.5
-    benchmark_data:
-      version: V1R1
-      profiles:
-          stig: {}
-      description: |-
-          ComplianceAsCode implementation of STIG Ubuntu 24.04 LTS V1R1 benchmark.
-      release_notes_url: https://github.com/canonical/ubuntu-security-guide/pull/72
-      reference_url: https://public.cyber.mil/stigs/downloads/
+- cac_tag: noble-stig-1.1
+  parent_tag: noble-stig-1.0
+  release_channel: 1
+  cac_commit: 2a365b363074306e970206e49a182e4771b431dc
+  usg_version: 24.04.6
+  benchmark_data:
+    version: V1R1
+    profiles:
+      stig: {}
+    description: ComplianceAsCode implementation of STIG Ubuntu 24.04 LTS V1R1 benchmark.
+    release_notes_url: https://github.com/canonical/ubuntu-security-guide/pull/110
+    reference_url: https://public.cyber.mil/stigs/downloads/
+- cac_tag: noble-stig-1.0
+  parent_tag: null
+  release_channel: 1
+  cac_commit: e40871066ec2edfce046b53241f0e02d4a184ea5
+  usg_version: 24.04.5
+  benchmark_data:
+    version: V1R1
+    profiles:
+      stig: {}
+    description: ComplianceAsCode implementation of STIG Ubuntu 24.04 LTS V1R1 benchmark.
+    release_notes_url: https://github.com/canonical/ubuntu-security-guide/pull/72
+    reference_url: https://public.cyber.mil/stigs/downloads/


### PR DESCRIPTION
#### Release info
- USG rewrite in Python (see https://github.com/canonical/ubuntu-security-guide/pull/76)
- Minor fixes and improvements for existing benchmark profiles

#### Changelog
  * Rewrite USG in Python:
    - Add support for multiple versions of benchmark profiles
    - Add funcionality to list and display informatino about profiles
    - Add functionality for fixing only failing rules (--only-failed)
    - Improve tests, configuration, logging
  * Rewrite build tooling to process multiple benchmarks
  * Switch to benchmarks package usg-benchmarks and drop debian-alternatives
  * Add bash completion for USG
  * Add autopkgtest script
  * Update CaC content:
    - Add support for distributed sshd configuration (CIS v1.0.0)
    - Add timeout for acquiring the APT lock to mitigate issues with
      failing rules due to unattended-upgrades running in the background
    - Improve set_loopback_traffic
    - Fix audit_rules_privileged_commands_kmod check to allow old auditd
      watch format (STIG V1R1)