### PR TITLE
Fix SCE glob to not include metadata.json in build

### DIFF
--- a/tools/process_benchmarks.py
+++ b/tools/process_benchmarks.py
@@ -561,7 +561,7 @@ def _build_active_releases(
             logger.debug("Copying SCE scripts...")
             sce_scripts = (
                 tmp_build_dir / "build" / cac_product / "checks/sce"
-                ).glob("*")
+                ).glob("*.sh")
             
             sce_dst_dir = output_benchmark_dir / cac_product / "checks/sce"
             sce_dst_dir.mkdir(parents=True)


### PR DESCRIPTION
- Existing glob includes all files in SCE dir including `metadata.json`, which is not needed.
- Limit the glob to shell scripts only.