### PR TITLE
Pin usg-benchmarks dependency to latest binary version

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,7 @@ Standards-Version: 4.6.2
 
 Package: usg
 Architecture: all
-Depends: usg-benchmarks, openscap-scanner, ${python3:Depends}, ${misc:Depends}
+Depends: usg-benchmarks (= ${binary:Version}), openscap-scanner, ${python3:Depends}, ${misc:Depends}
 Conflicts: usg-common
 Recommends: usg-benchmarks-1
 Description: tool for security auditing and hardening


### PR DESCRIPTION
This ensures usg and usg-benchmarks are always upgraded to the same version, even when running 'apt install usg' on an existing installation, which otherwise upgrades the usg package but does not update usg-benchmarks.

Fixes https://bugs.launchpad.net/usg/+bug/2136296