### PR TITLE
Add exclusion for copyright year in snapshot test

### DIFF
--- a/tools/tests/test_build.py
+++ b/tools/tests/test_build.py
@@ -60,6 +60,9 @@ def compare_files(expected_file, actual_file):
             expected_text_subbed, actual_text_subbed = replace_dynamic_content(
                 expected_text, actual_text, r"^% .*"
             )
+            expected_text_subbed, actual_text_subbed = replace_dynamic_content(
+                expected_text_subbed, actual_text_subbed, r"^Copyright \d+ "
+            )
         else:
             expected_text_subbed = expected_text
             actual_text_subbed = actual_text


### PR DESCRIPTION
The build tests were failing due to the change in year in manpages. This PR excludes these lines from the diff check.