### PR TITLE
Version 22.04.17

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,22 @@
+ubuntu-security-guides-enhanced (22.04.17) jammy; urgency=medium
+
+  * CaC content - CIS v2.0.0:
+    - Add missing section to systemd-timesyncd configuration (LP: #2135245)
+    - Improve set_loopback_traffic SCE check
+    - Add support for drop-in config files in journald rules
+    - Add missing rules for sshd drop-in config file permissions
+    - Add 60s timeout for acquiring the APT lock
+  * CaC content - STIG v2r3:
+    - Override auditd_kmod OVAL check to allow old watch format
+    - Add 60s timeout for acquiring the APT lock
+  * CaC content - CIS v1.0.0:
+    - Set permissions on bootloader config (EC2 profile)
+    - Add 60s timeout for acquiring the APT lock
+  * USG tool:
+    - Pin usg-benchmarks dependency to latest binary version (LP: #2136296)
+
+ -- Miha Purg <miha.purg@canonical.com>  Fri, 06 Feb 2026 15:26:15 +0100
+
 ubuntu-security-guides-enhanced (22.04.16) jammy; urgency=medium
 
   * Fix errors in SCE checks when /tmp is mounted with noexec (LP: #2133895)

--- a/debian/control
+++ b/debian/control
@@ -14,7 +14,7 @@ Standards-Version: 4.6.2
 
 Package: usg
 Architecture: all
-Depends: usg-benchmarks, libopenscap8, bsdmainutils, ${python3:Depends}, ${misc:Depends}
+Depends: usg-benchmarks (= ${binary:Version}), libopenscap8, bsdmainutils, ${python3:Depends}, ${misc:Depends}
 Conflicts: usg-common
 Recommends: usg-benchmarks-1
 Description: tool for security auditing and hardening

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 # pyproject.toml (PEP 621) is not supported in setuptools < 61
 [metadata]
 name = usg
-version = 22.04.16
+version = 22.04.17
 
 [options]
 packages = find:

--- a/tools/release_metadata/jammy_cis_benchmarks.yml
+++ b/tools/release_metadata/jammy_cis_benchmarks.yml
@@ -3,6 +3,22 @@ general:
   product: ubuntu2204
   product_long: Ubuntu 22.04 LTS (Jammy Jellyfish)
 benchmark_releases:
+- cac_tag: jammy-cis-1.15
+  parent_tag: jammy-cis-1.14
+  release_channel: 1
+  cac_commit: 57b72437a2e962f92e226a57c77f7a2f684d4088
+  usg_version: 22.04.17
+  benchmark_data:
+    version: v1.0.0
+    profiles:
+      cis_level1_server: {}
+      cis_level1_server_ec2: {}
+      cis_level2_server: {}
+      cis_level1_workstation: {}
+      cis_level2_workstation: {}
+    description: ComplianceAsCode implementation of CIS Ubuntu 22.04 LTS v1.0.0 benchmark.
+    release_notes_url: https://github.com/canonical/ubuntu-security-guide/pull/118
+    reference_url: https://www.cisecurity.org/benchmark/ubuntu_linux/
 - cac_tag: jammy-cis-2.1
   parent_tag: jammy-cis-1.14
   release_channel: 2

--- a/tools/release_metadata/jammy_cis_benchmarks.yml
+++ b/tools/release_metadata/jammy_cis_benchmarks.yml
@@ -3,6 +3,21 @@ general:
   product: ubuntu2204
   product_long: Ubuntu 22.04 LTS (Jammy Jellyfish)
 benchmark_releases:
+- cac_tag: jammy-cis-2.2
+  parent_tag: jammy-cis-2.1
+  release_channel: 2
+  cac_commit: e8ca6b6559976a5db9f28104b1f235f07730e2f0
+  usg_version: 22.04.17
+  benchmark_data:
+    version: v2.0.0
+    profiles:
+      cis_level1_server: {}
+      cis_level2_server: {}
+      cis_level1_workstation: {}
+      cis_level2_workstation: {}
+    description: ComplianceAsCode implementation of CIS Ubuntu 22.04 LTS v2.0.0 benchmark.
+    release_notes_url: https://github.com/canonical/ubuntu-security-guide/pull/118
+    reference_url: https://www.cisecurity.org/benchmark/ubuntu_linux/
 - cac_tag: jammy-cis-1.15
   parent_tag: jammy-cis-1.14
   release_channel: 1

--- a/tools/release_metadata/jammy_stig_benchmarks.yml
+++ b/tools/release_metadata/jammy_stig_benchmarks.yml
@@ -3,6 +3,18 @@ general:
   product: ubuntu2204
   product_long: Ubuntu 22.04 LTS (Jammy Jellyfish)
 benchmark_releases:
+- cac_tag: jammy-stig-1.8
+  parent_tag: jammy-stig-1.7
+  release_channel: 1
+  cac_commit: 8eddc72f4a70d69739333337e8730975e0ecd7ac
+  usg_version: 22.04.17
+  benchmark_data:
+    version: V2R3
+    profiles:
+      stig: {}
+    description: ComplianceAsCode implementation of STIG Ubuntu 22.04 LTS V2R3 benchmark.
+    release_notes_url: https://github.com/canonical/ubuntu-security-guide/pull/118
+    reference_url: https://public.cyber.mil/stigs/downloads/
 - cac_tag: jammy-stig-1.7
   parent_tag: jammy-stig-1.6
   release_channel: 1

--- a/tools/tests/test_build.py
+++ b/tools/tests/test_build.py
@@ -60,6 +60,9 @@ def compare_files(expected_file, actual_file):
             expected_text_subbed, actual_text_subbed = replace_dynamic_content(
                 expected_text, actual_text, r"^% .*"
             )
+            expected_text_subbed, actual_text_subbed = replace_dynamic_content(
+                expected_text_subbed, actual_text_subbed, r"^Copyright \d+ "
+            )
         else:
             expected_text_subbed = expected_text
             actual_text_subbed = actual_text


### PR DESCRIPTION
#### Release info
- Minor fixes and improvements to CaC content
- Fixed version pinning for usg-benchmarks

#### Changelog

  * CaC content - CIS v2.0.0:
    - Add missing section to systemd-timesyncd configuration (LP: #2135245)
    - Improve set_loopback_traffic SCE check
    - Add support for drop-in config files in journald rules
    - Add missing rules for sshd drop-in config file permissions
    - Add 60s timeout for acquiring the APT lock
  * CaC content - STIG v2r3:
    - Override auditd_kmod OVAL check to allow old watch format
    - Add 60s timeout for acquiring the APT lock
  * CaC content - CIS v1.0.0:
    - Set permissions on bootloader config (EC2 profile)
    - Add 60s timeout for acquiring the APT lock
  * USG tool:
    - Pin usg-benchmarks dependency to latest binary version (LP: #2136296)