### PR TITLE
Add cis_level1_server_ec2 profile to release metadata

### DIFF
--- a/tools/release_metadata/noble_cis_benchmarks.yml
+++ b/tools/release_metadata/noble_cis_benchmarks.yml
@@ -15,6 +15,7 @@ benchmark_releases:
       cis_level2_server: {}
       cis_level1_workstation: {}
       cis_level2_workstation: {}
+      cis_level1_server_ec2: {}
     description: ComplianceAsCode implementation of CIS Ubuntu 24.04 LTS v1.0.0 benchmark.
     release_notes_url: https://github.com/canonical/ubuntu-security-guide/pull/110
     reference_url: https://www.cisecurity.org/benchmark/ubuntu_linux/
@@ -30,6 +31,7 @@ benchmark_releases:
       cis_level2_server: {}
       cis_level1_workstation: {}
       cis_level2_workstation: {}
+      cis_level1_server_ec2: {}
     description: ComplianceAsCode implementation of CIS Ubuntu 24.04 LTS v1.0.0 benchmark.
     release_notes_url: https://github.com/canonical/ubuntu-security-guide/pull/72
     reference_url: https://www.cisecurity.org/benchmark/ubuntu_linux/

--- a/tools/tests/test_build.py
+++ b/tools/tests/test_build.py
@@ -60,6 +60,9 @@ def compare_files(expected_file, actual_file):
             expected_text_subbed, actual_text_subbed = replace_dynamic_content(
                 expected_text, actual_text, r"^% .*"
             )
+            expected_text_subbed, actual_text_subbed = replace_dynamic_content(
+                expected_text_subbed, actual_text_subbed, r"^Copyright \d+ "
+            )
         else:
             expected_text_subbed = expected_text
             actual_text_subbed = actual_text


### PR DESCRIPTION
Add `cis_level1_server_ec2` profile to release metadata file for Noble CIS.

Also backport #117 to fix CI issues.