### PR TITLE
22.04.18 dev

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+ubuntu-security-guides-enhanced (22.04.18) jammy; urgency=medium
+
+  * CaC content - CIS v2.0.0:
+    - Fix /var/log ownership rules to account for non-shell accounts (LP: #2142301)
+    - Improve chronyd_configure_pool_and_server rule to add trailing newline (LP: #2141667)
+    - Fix incorrect username parsing in file_owner template (LP: #2137602)
+  * USG tool:
+    - Fix benchmark version and release date in tailoring files (LP: #2142286)
+ 
+
+ -- Miha Purg <miha.purg@canonical.com>  Thu, 12 Mar 2026 09:56:14 +0100
+
 ubuntu-security-guides-enhanced (22.04.17) jammy; urgency=medium
 
   * CaC content - CIS v2.0.0:

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 # pyproject.toml (PEP 621) is not supported in setuptools < 61
 [metadata]
 name = usg
-version = 22.04.17
+version = 22.04.18
 
 [options]
 packages = find:

--- a/src/usg/models.py
+++ b/src/usg/models.py
@@ -54,6 +54,7 @@ class ReleaseChannel:
     """Immutable representation of a benchmark release channel."""
 
     id: str
+    latest_benchmark_id: str
     benchmark_ids: list[str]
     channel_number: int
     is_latest: bool
@@ -83,6 +84,7 @@ class ReleaseChannel:
             }
             return cls(
                 id=data["id"],
+                latest_benchmark_id=data["latest_benchmark_id"],
                 benchmark_ids=data["benchmark_ids"],
                 channel_number=data["channel_number"],
                 is_latest=data["is_latest"],

--- a/templates/tailoring/cis_level1_server-tailoring.xml
+++ b/templates/tailoring/cis_level1_server-tailoring.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Tailoring xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_scap-workbench_tailoring_default">
-  <benchmark href="PLACEHOLDER"/>
-  <version time="PLACEHOLDER">1</version>
+  <benchmark href="${benchmark_href}"/>
+  <version time="${timestamp}">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level1_server_customized"
       extends="xccdf_org.ssgproject.content_profile_cis_level1_server">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 22.04 Level 1 Server Benchmark [CUSTOMIZED]</title>
-    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 22.04 LTS Benchmark, v1.0.0, released 08-30-2022.</description>
+    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 22.04 LTS Benchmark, ${benchmark_version}, released ${benchmark_release_date}.</description>
   </Profile>
 </Tailoring>

--- a/templates/tailoring/cis_level1_server_ec2-tailoring.xml
+++ b/templates/tailoring/cis_level1_server_ec2-tailoring.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Tailoring xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_scap-workbench_tailoring_default">
-  <benchmark href="PLACEHOLDER"/>
-  <version time="PLACEHOLDER">1</version>
+  <benchmark href="${benchmark_href}"/>
+  <version time="${timestamp}">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level1_server_ec2_customized"
       extends="xccdf_org.ssgproject.content_profile_cis_level1_server_ec2">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 22.04 Level 1 Server Benchmark - EC2 [CUSTOMIZED]</title>
-    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 22.04 LTS Benchmark, v1.0.0, released 08-30-2022. The EC2 profile is a strict subset of the Level 1 Server profile tailored for Amazon EC2 images.</description>
+    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 22.04 LTS Benchmark, ${benchmark_version}, released ${benchmark_release_date}. The EC2 profile is a strict subset of the Level 1 Server profile tailored for Amazon EC2 images.</description>
   </Profile>
 </Tailoring>

--- a/templates/tailoring/cis_level1_workstation-tailoring.xml
+++ b/templates/tailoring/cis_level1_workstation-tailoring.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Tailoring xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_scap-workbench_tailoring_default">
-  <benchmark href="PLACEHOLDER"/>
-  <version time="PLACEHOLDER">1</version>
+  <benchmark href="${benchmark_href}"/>
+  <version time="${timestamp}">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level1_workstation_customized"
       extends="xccdf_org.ssgproject.content_profile_cis_level1_workstation">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 22.04 Level 1 Workstation Benchmark [CUSTOMIZED]</title>
-    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 22.04 LTS Benchmark, v1.0.0, released 08-30-2022.</description>
+    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 22.04 LTS Benchmark, ${benchmark_version}, released ${benchmark_release_date}.</description>
   </Profile>
 </Tailoring>

--- a/templates/tailoring/cis_level2_server-tailoring.xml
+++ b/templates/tailoring/cis_level2_server-tailoring.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Tailoring xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_scap-workbench_tailoring_default">
-  <benchmark href="PLACEHOLDER"/>
-  <version time="PLACEHOLDER">1</version>
+  <benchmark href="${benchmark_href}"/>
+  <version time="${timestamp}">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level2_server_customized"
       extends="xccdf_org.ssgproject.content_profile_cis_level2_server">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 22.04 Level 2 Server Benchmark [CUSTOMIZED]</title>
-    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 22.04 LTS Benchmark, v1.0.0, released 08-30-2022.</description>
+    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 22.04 LTS Benchmark, ${benchmark_version}, released ${benchmark_release_date}.</description>
   </Profile>
 </Tailoring>

--- a/templates/tailoring/cis_level2_workstation-tailoring.xml
+++ b/templates/tailoring/cis_level2_workstation-tailoring.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Tailoring xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_scap-workbench_tailoring_default">
-  <benchmark href="PLACEHOLDER"/>
-  <version time="PLACEHOLDER">1</version>
+  <benchmark href="${benchmark_href}"/>
+  <version time="${timestamp}">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level2_workstation_customized"
       extends="xccdf_org.ssgproject.content_profile_cis_level2_workstation">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 22.04 Level 2 Workstation Benchmark [CUSTOMIZED]</title>
-    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 22.04 LTS Benchmark, v1.0.0, released 08-30-2022.</description>
+    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 22.04 LTS Benchmark, ${benchmark_version}, released ${benchmark_release_date}.</description>
   </Profile>
 </Tailoring>

--- a/templates/tailoring/stig-tailoring.xml
+++ b/templates/tailoring/stig-tailoring.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Tailoring xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_scap-workbench_tailoring_default">
-  <benchmark href="PLACEHOLDER"/>
-  <version time="PLACEHOLDER">1</version>
+  <benchmark href="${benchmark_href}"/>
+  <version time="${timestamp}">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_stig_customized"
       extends="xccdf_org.ssgproject.content_profile_stig">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">DISA-STIG Benchmark [CUSTOMIZED]</title>
-    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the DISA-STIG v.1, rel.1, released 2024-04-10.</description>
+    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the DISA-STIG ${benchmark_version}, released ${benchmark_release_date}.</description>
   </Profile>
 </Tailoring>

--- a/tests/data/ubuntu2204/expected/benchmarks/benchmarks.json
+++ b/tests/data/ubuntu2204/expected/benchmarks/benchmarks.json
@@ -62,12 +62,14 @@
       },
       "description": "ComplianceAsCode implementation of CIS Ubuntu 22.04 LTS v1.0.0 benchmark.\n",
       "release_notes_url": "https://github.com/canonical/ubuntu-security-guide/pull/72",
-      "reference_url": "https://www.cisecurity.org/benchmark/ubuntu_linux/"
+      "reference_url": "https://www.cisecurity.org/benchmark/ubuntu_linux/",
+      "release_date": "2022-08-30"
     }
   ],
   "release_channels": [
     {
       "id": "ubuntu2204_CIS_1",
+      "latest_benchmark_id": "ubuntu2204_CIS_1-v1.0.0",
       "benchmark_ids": [
         "ubuntu2204_CIS_1-v1.0.0"
       ],
@@ -114,19 +116,19 @@
       "tailoring_files": {
         "cis_level1_server": {
           "path": "ubuntu2204_CIS_1/tailoring/cis_level1_server-tailoring.xml",
-          "sha256": "8e21dbf26af2cca82677762a0538d6e80a2c9d7460c0f0ccfbd452a4c5fe8515"
+          "sha256": "b38485596080fb772fef0ccaa7473627dfb2e0b2520785cd7dac7174ea07c3e3"
         },
         "cis_level2_server": {
           "path": "ubuntu2204_CIS_1/tailoring/cis_level2_server-tailoring.xml",
-          "sha256": "b853d52b5b0f74e83526572140a2d86c530e3dd4306f1e51ce15dd1958f4a7b2"
+          "sha256": "91afc0d49ee6abe460208b969ea5ee19a5bc95821b522d60e4c7584d1720e062"
         },
         "cis_level1_workstation": {
           "path": "ubuntu2204_CIS_1/tailoring/cis_level1_workstation-tailoring.xml",
-          "sha256": "e53604488f0b3471cb4077f53e8a4fbfad4e65b17981aee9d87f4445bb5121bf"
+          "sha256": "79e748a8e5fdfc59d782117fa1ff940bb0b1f21bd7868cab85174015763ed838"
         },
         "cis_level2_workstation": {
           "path": "ubuntu2204_CIS_1/tailoring/cis_level2_workstation-tailoring.xml",
-          "sha256": "d4035350c83f06a571c8c86dda9bb814609d9e61414d28726f7a30a35ac35c48"
+          "sha256": "5525e69dd955b3671aca9cc87f86be1f95c26cffc5eedffd9fdb3885ad5d081e"
         }
       }
     }

--- a/tests/data/ubuntu2204/expected/benchmarks/ubuntu2204_CIS_1/tailoring/cis_level1_server-tailoring.xml
+++ b/tests/data/ubuntu2204/expected/benchmarks/ubuntu2204_CIS_1/tailoring/cis_level1_server-tailoring.xml
@@ -4,7 +4,7 @@
   <version time="1970-01-01T00:00:01+00:00">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level1_server_customized" extends="xccdf_org.ssgproject.content_profile_cis_level1_server">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 22.04 Level 1 Server Benchmark [CUSTOMIZED]</title>
-    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 22.04 LTS Benchmark, v1.0.0, released 08-30-2022.</description>
+    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 22.04 LTS Benchmark, v1.0.0, released 2022-08-30.</description>
     <!--_Profile_Rules_And_Variables_: Profile rules and variables not belonging to a specific control-->
     <set-value idref="xccdf_org.ssgproject.content_value_var_apparmor_mode">enforce</set-value>
     <set-value idref="xccdf_org.ssgproject.content_value_login_banner_text">^Authorized[\s\n]+uses[\s\n]+only\.[\s\n]+All[\s\n]+activity[\s\n]+may[\s\n]+be[\s\n]+monitored[\s\n]+and[\s\n]+reported\.$</set-value>

--- a/tests/data/ubuntu2204/expected/benchmarks/ubuntu2204_CIS_1/tailoring/cis_level1_workstation-tailoring.xml
+++ b/tests/data/ubuntu2204/expected/benchmarks/ubuntu2204_CIS_1/tailoring/cis_level1_workstation-tailoring.xml
@@ -4,7 +4,7 @@
   <version time="1970-01-01T00:00:01+00:00">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level1_workstation_customized" extends="xccdf_org.ssgproject.content_profile_cis_level1_workstation">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 22.04 Level 1 Workstation Benchmark [CUSTOMIZED]</title>
-    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 22.04 LTS Benchmark, v1.0.0, released 08-30-2022.</description>
+    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 22.04 LTS Benchmark, v1.0.0, released 2022-08-30.</description>
     <!--_Profile_Rules_And_Variables_: Profile rules and variables not belonging to a specific control-->
     <select idref="xccdf_org.ssgproject.content_rule_service_autofs_disabled" selected="false"/>
     <select idref="xccdf_org.ssgproject.content_rule_kernel_module_usb-storage_disabled" selected="false"/>

--- a/tests/data/ubuntu2204/expected/benchmarks/ubuntu2204_CIS_1/tailoring/cis_level2_server-tailoring.xml
+++ b/tests/data/ubuntu2204/expected/benchmarks/ubuntu2204_CIS_1/tailoring/cis_level2_server-tailoring.xml
@@ -4,7 +4,7 @@
   <version time="1970-01-01T00:00:01+00:00">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level2_server_customized" extends="xccdf_org.ssgproject.content_profile_cis_level2_server">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 22.04 Level 2 Server Benchmark [CUSTOMIZED]</title>
-    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 22.04 LTS Benchmark, v1.0.0, released 08-30-2022.</description>
+    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 22.04 LTS Benchmark, v1.0.0, released 2022-08-30.</description>
     <!--_Profile_Rules_And_Variables_: Profile rules and variables not belonging to a specific control-->
     <set-value idref="xccdf_org.ssgproject.content_value_var_apparmor_mode">enforce</set-value>
     <set-value idref="xccdf_org.ssgproject.content_value_var_auditd_max_log_file">6</set-value>

--- a/tests/data/ubuntu2204/expected/benchmarks/ubuntu2204_CIS_1/tailoring/cis_level2_workstation-tailoring.xml
+++ b/tests/data/ubuntu2204/expected/benchmarks/ubuntu2204_CIS_1/tailoring/cis_level2_workstation-tailoring.xml
@@ -4,7 +4,7 @@
   <version time="1970-01-01T00:00:01+00:00">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level2_workstation_customized" extends="xccdf_org.ssgproject.content_profile_cis_level2_workstation">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 22.04 Level 2 Workstation Benchmark [CUSTOMIZED]</title>
-    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 22.04 LTS Benchmark, v1.0.0, released 08-30-2022.</description>
+    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 22.04 LTS Benchmark, v1.0.0, released 2022-08-30.</description>
     <!--_Profile_Rules_And_Variables_: Profile rules and variables not belonging to a specific control-->
     <set-value idref="xccdf_org.ssgproject.content_value_var_apparmor_mode">enforce</set-value>
     <select idref="xccdf_org.ssgproject.content_rule_kernel_module_squashfs_disabled" selected="true"/>

--- a/tests/data/ubuntu2204/input/templates/tailoring/cis_level1_server-tailoring.xml
+++ b/tests/data/ubuntu2204/input/templates/tailoring/cis_level1_server-tailoring.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Tailoring xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_scap-workbench_tailoring_default">
-  <benchmark href="PLACEHOLDER"/>
-  <version time="PLACEHOLDER">1</version>
+  <benchmark href="${benchmark_href}"/>
+  <version time="${timestamp}">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level1_server_customized"
       extends="xccdf_org.ssgproject.content_profile_cis_level1_server">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 22.04 Level 1 Server Benchmark [CUSTOMIZED]</title>
-    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 22.04 LTS Benchmark, v1.0.0, released 08-30-2022.</description>
+    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 22.04 LTS Benchmark, ${benchmark_version}, released ${benchmark_release_date}.</description>
   </Profile>
 </Tailoring>

--- a/tests/data/ubuntu2204/input/templates/tailoring/cis_level1_workstation-tailoring.xml
+++ b/tests/data/ubuntu2204/input/templates/tailoring/cis_level1_workstation-tailoring.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Tailoring xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_scap-workbench_tailoring_default">
-  <benchmark href="PLACEHOLDER"/>
-  <version time="PLACEHOLDER">1</version>
+  <benchmark href="${benchmark_href}"/>
+  <version time="${timestamp}">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level1_workstation_customized"
       extends="xccdf_org.ssgproject.content_profile_cis_level1_workstation">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 22.04 Level 1 Workstation Benchmark [CUSTOMIZED]</title>
-    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 22.04 LTS Benchmark, v1.0.0, released 08-30-2022.</description>
+    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 22.04 LTS Benchmark, ${benchmark_version}, released ${benchmark_release_date}.</description>
   </Profile>
 </Tailoring>

--- a/tests/data/ubuntu2204/input/templates/tailoring/cis_level2_server-tailoring.xml
+++ b/tests/data/ubuntu2204/input/templates/tailoring/cis_level2_server-tailoring.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Tailoring xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_scap-workbench_tailoring_default">
-  <benchmark href="PLACEHOLDER"/>
-  <version time="PLACEHOLDER">1</version>
+  <benchmark href="${benchmark_href}"/>
+  <version time="${timestamp}">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level2_server_customized"
       extends="xccdf_org.ssgproject.content_profile_cis_level2_server">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 22.04 Level 2 Server Benchmark [CUSTOMIZED]</title>
-    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 22.04 LTS Benchmark, v1.0.0, released 08-30-2022.</description>
+    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 22.04 LTS Benchmark, ${benchmark_version}, released ${benchmark_release_date}.</description>
   </Profile>
 </Tailoring>

--- a/tests/data/ubuntu2204/input/templates/tailoring/cis_level2_workstation-tailoring.xml
+++ b/tests/data/ubuntu2204/input/templates/tailoring/cis_level2_workstation-tailoring.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Tailoring xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_scap-workbench_tailoring_default">
-  <benchmark href="PLACEHOLDER"/>
-  <version time="PLACEHOLDER">1</version>
+  <benchmark href="${benchmark_href}"/>
+  <version time="${timestamp}">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level2_workstation_customized"
       extends="xccdf_org.ssgproject.content_profile_cis_level2_workstation">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 22.04 Level 2 Workstation Benchmark [CUSTOMIZED]</title>
-    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 22.04 LTS Benchmark, v1.0.0, released 08-30-2022.</description>
+    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 22.04 LTS Benchmark, ${benchmark_version}, released ${benchmark_release_date}.</description>
   </Profile>
 </Tailoring>

--- a/tests/data/ubuntu2204/input/tools/release_metadata/jammy_cis_benchmarks.yml
+++ b/tests/data/ubuntu2204/input/tools/release_metadata/jammy_cis_benchmarks.yml
@@ -20,3 +20,4 @@ benchmark_releases:
           ComplianceAsCode implementation of CIS Ubuntu 22.04 LTS v1.0.0 benchmark.
       release_notes_url: https://github.com/canonical/ubuntu-security-guide/pull/72
       reference_url: https://www.cisecurity.org/benchmark/ubuntu_linux/
+      release_date: 2022-08-30

--- a/tests/data/ubuntu2404/expected/benchmarks/benchmarks.json
+++ b/tests/data/ubuntu2404/expected/benchmarks/benchmarks.json
@@ -177,7 +177,8 @@
       },
       "description": "ComplianceAsCode implementation of CIS Ubuntu 24.04 LTS v1.0.0 benchmark.",
       "release_notes_url": "https://github.com/canonical/ubuntu-security-guide/",
-      "reference_url": "https://www.cisecurity.org/benchmark/ubuntu_linux/"
+      "reference_url": "https://www.cisecurity.org/benchmark/ubuntu_linux/",
+      "release_date": "2024-08-26"
     },
     {
       "id": "ubuntu2404_CIS_2-v1.0.0.usg1",
@@ -198,7 +199,8 @@
       },
       "description": "ComplianceAsCode implementation of CIS Ubuntu 24.04 LTS v1.0.0 benchmark.",
       "release_notes_url": "https://github.com/canonical/ubuntu-security-guide/",
-      "reference_url": "https://www.cisecurity.org/benchmark/ubuntu_linux/"
+      "reference_url": "https://www.cisecurity.org/benchmark/ubuntu_linux/",
+      "release_date": "in_the_future"
     },
     {
       "id": "ubuntu2404_CIS_2-v1.0.1",
@@ -219,7 +221,8 @@
       },
       "description": "ComplianceAsCode implementation of CIS Ubuntu 24.04 LTS v1.0.1 benchmark.",
       "release_notes_url": "https://github.com/canonical/ubuntu-security-guide/",
-      "reference_url": "https://www.cisecurity.org/benchmark/ubuntu_linux/"
+      "reference_url": "https://www.cisecurity.org/benchmark/ubuntu_linux/",
+      "release_date": "in_the_future"
     },
     {
       "id": "ubuntu2404_CIS_3-v2.0.0",
@@ -239,7 +242,8 @@
       },
       "description": "ComplianceAsCode implementation of CIS Ubuntu 24.04 LTS v2.0.0 benchmark.",
       "release_notes_url": "https://github.com/canonical/ubuntu-security-guide/",
-      "reference_url": "https://www.cisecurity.org/benchmark/ubuntu_linux/"
+      "reference_url": "https://www.cisecurity.org/benchmark/ubuntu_linux/",
+      "release_date": "in_the_future"
     },
     {
       "id": "ubuntu2404_STIG_1-V1R1",
@@ -257,7 +261,8 @@
       },
       "description": "ComplianceAsCode implementation of STIG Ubuntu 24.04 LTS V1R1 benchmark.",
       "release_notes_url": "https://github.com/canonical/ubuntu-security-guide/",
-      "reference_url": "https://public.cyber.mil/stigs/downloads/"
+      "reference_url": "https://public.cyber.mil/stigs/downloads/",
+      "release_date": "2025-01-28"
     },
     {
       "id": "ubuntu2404_STIG_2-V1R2",
@@ -275,7 +280,8 @@
       },
       "description": "ComplianceAsCode implementation of STIG Ubuntu 24.04 LTS V1R2 benchmark.",
       "release_notes_url": "https://github.com/canonical/ubuntu-security-guide/",
-      "reference_url": "https://public.cyber.mil/stigs/downloads/"
+      "reference_url": "https://public.cyber.mil/stigs/downloads/",
+      "release_date": "in_the_future"
     },
     {
       "id": "ubuntu2404_STIG_2-V1R3",
@@ -293,12 +299,14 @@
       },
       "description": "ComplianceAsCode implementation of STIG Ubuntu 24.04 LTS V1R3 benchmark.",
       "release_notes_url": "https://github.com/canonical/ubuntu-security-guide/",
-      "reference_url": "https://public.cyber.mil/stigs/downloads/"
+      "reference_url": "https://public.cyber.mil/stigs/downloads/",
+      "release_date": "in_the_future"
     }
   ],
   "release_channels": [
     {
       "id": "ubuntu2404_CIS_1",
+      "latest_benchmark_id": "ubuntu2404_CIS_1-v1.0.0",
       "benchmark_ids": [
         "ubuntu2404_CIS_1-v1.0.0"
       ],
@@ -345,24 +353,25 @@
       "tailoring_files": {
         "cis_level1_server": {
           "path": "ubuntu2404_CIS_1/tailoring/cis_level1_server-tailoring.xml",
-          "sha256": "40fdfe10a2bd09db8a4ff00f423da15d5dfe6abd7947f63d454858e61f838acb"
+          "sha256": "38da2806b06651af75be349464d3d1a7ca3e5cb4c8e4bae79f9d522baade6025"
         },
         "cis_level2_server": {
           "path": "ubuntu2404_CIS_1/tailoring/cis_level2_server-tailoring.xml",
-          "sha256": "e99ff55293caf4112cf8507136a8a50985386521314a09f8d02684acf2ee871c"
+          "sha256": "5abe51d80d6da53937e24e35c6b91fc5a6caf021147ff965ee867ad1ee22a44d"
         },
         "cis_level1_workstation": {
           "path": "ubuntu2404_CIS_1/tailoring/cis_level1_workstation-tailoring.xml",
-          "sha256": "a6ed77738a5e97bc152027f3790cbda92cc6f171ed6d620ec30fa2e7c05ac2f1"
+          "sha256": "e5ed864dc7a33fe332c2982a103558666733865054faad9676de558481af1f5a"
         },
         "cis_level2_workstation": {
           "path": "ubuntu2404_CIS_1/tailoring/cis_level2_workstation-tailoring.xml",
-          "sha256": "4848e8aa8da869dff3419e7c8b8dccf89fce094dd4b9af4af22a27232c03f6b9"
+          "sha256": "c7c050f284abee3ae21e2eb1a0baef38749f10c5ce5e2e1e60063a2b56a7c5d7"
         }
       }
     },
     {
       "id": "ubuntu2404_CIS_2",
+      "latest_benchmark_id": "ubuntu2404_CIS_2-v1.0.1",
       "benchmark_ids": [
         "ubuntu2404_CIS_2-v1.0.0.usg1",
         "ubuntu2404_CIS_2-v1.0.1"
@@ -410,24 +419,25 @@
       "tailoring_files": {
         "cis_level1_server": {
           "path": "ubuntu2404_CIS_2/tailoring/cis_level1_server-tailoring.xml",
-          "sha256": "d91b9fd28372d617b1e86af5a7fbadd9644708e40e1ca669062083181638d6d2"
+          "sha256": "c7b15385f3ec25f2e513a9f909f5369358d3c07f8c4dac086057817e94169942"
         },
         "cis_level2_server": {
           "path": "ubuntu2404_CIS_2/tailoring/cis_level2_server-tailoring.xml",
-          "sha256": "a47d4e557e7c3a3e0fa14f320a2550db2a9ed52766239e11fedb6bf56273b578"
+          "sha256": "4c2cd791c54e5fb85e5d6ea5201ec1974d6529cb2e18dfbfde0e9b1621ed0bbc"
         },
         "cis_level1_workstation": {
           "path": "ubuntu2404_CIS_2/tailoring/cis_level1_workstation-tailoring.xml",
-          "sha256": "43954c3f8851858d10e436c1d947bec13bf1491412e14fd9c10104de008671be"
+          "sha256": "a34071e20b673192241a98f0139a69b5cb9685764daa5cc73b60a8af582c548e"
         },
         "cis_level2_workstation": {
           "path": "ubuntu2404_CIS_2/tailoring/cis_level2_workstation-tailoring.xml",
-          "sha256": "68106821091b132721cc6e0d3f43db6fb7dd3b3403a07d06b0288c0e763ca7a1"
+          "sha256": "bfa01ba7e4225a1606f37c401ec2e97fe0793d8ebb202e12303fc4f8d2b79b8b"
         }
       }
     },
     {
       "id": "ubuntu2404_CIS_3",
+      "latest_benchmark_id": "ubuntu2404_CIS_3-v2.0.0",
       "benchmark_ids": [
         "ubuntu2404_CIS_3-v2.0.0"
       ],
@@ -473,20 +483,21 @@
       "tailoring_files": {
         "cis_level1_server": {
           "path": "ubuntu2404_CIS_3/tailoring/cis_level1_server-tailoring.xml",
-          "sha256": "17cf49e248d595712829c6d29f59fda08d26a8b1b60571c12993d7144122b2c1"
+          "sha256": "da9c95df62b5a06250e53900417e26f882c3cd864931fd4ffbf6198fb68abef2"
         },
         "cis_level2_server": {
           "path": "ubuntu2404_CIS_3/tailoring/cis_level2_server-tailoring.xml",
-          "sha256": "3e74bdfbf075934e9f06ac2c39f8f181f9769f6f486a6c68bf7b128f83cdd605"
+          "sha256": "330aa92b81abb2b1a4ec7541a66681ab94c6377ad4b4ddc70b04c8a18e7e4b19"
         },
         "cis_level1_workstation": {
           "path": "ubuntu2404_CIS_3/tailoring/cis_level1_workstation-tailoring.xml",
-          "sha256": "f745905551347a63e4134b33a3ab4313e3290fe8a7b3b1493af79917bf47429a"
+          "sha256": "11e346a8e93a8b84da725cafad36be5da513945fe7dff2d21333116eaa26b36e"
         }
       }
     },
     {
       "id": "ubuntu2404_STIG_1",
+      "latest_benchmark_id": "ubuntu2404_STIG_1-V1R1",
       "benchmark_ids": [
         "ubuntu2404_STIG_1-V1R1"
       ],
@@ -530,12 +541,13 @@
       "tailoring_files": {
         "stig": {
           "path": "ubuntu2404_STIG_1/tailoring/stig-tailoring.xml",
-          "sha256": "a76157f82edcb81953b5bd9d1dbb300249ca8d75eb3b613a98d1e56593a27851"
+          "sha256": "899321197449679af153c7eef3a242efd8624abdf483f290abfad715fa013185"
         }
       }
     },
     {
       "id": "ubuntu2404_STIG_2",
+      "latest_benchmark_id": "ubuntu2404_STIG_2-V1R3",
       "benchmark_ids": [
         "ubuntu2404_STIG_2-V1R2",
         "ubuntu2404_STIG_2-V1R3"
@@ -580,7 +592,7 @@
       "tailoring_files": {
         "stig": {
           "path": "ubuntu2404_STIG_2/tailoring/stig-tailoring.xml",
-          "sha256": "8cc81c293bfef3ec75acbef9a45283cef70ddb73583758fed684be19cd8279fb"
+          "sha256": "4abc8c496332877da83e06add33fb99c36319e3b52dca87dc8493b3ea380424b"
         }
       }
     }

--- a/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_1/tailoring/cis_level1_server-tailoring.xml
+++ b/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_1/tailoring/cis_level1_server-tailoring.xml
@@ -4,7 +4,7 @@
   <version time="1970-01-01T00:00:01+00:00">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level1_server_customized" extends="xccdf_org.ssgproject.content_profile_cis_level1_server">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 24.04 Level 1 Server Benchmark [CUSTOMIZED]</title>
-    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 24.04 LTS Benchmark, v1.0.0, released 08-26-2024.</description>
+    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 24.04 LTS Benchmark, v1.0.0, released 2024-08-26.</description>
     <!--1.1.1.1: Ensure cramfs kernel module is not available (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_kernel_module_cramfs_disabled" selected="true"/>
     <!--1.1.1.2: Ensure freevxfs kernel module is not available (Automated)-->

--- a/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_1/tailoring/cis_level1_workstation-tailoring.xml
+++ b/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_1/tailoring/cis_level1_workstation-tailoring.xml
@@ -4,7 +4,7 @@
   <version time="1970-01-01T00:00:01+00:00">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level1_workstation_customized" extends="xccdf_org.ssgproject.content_profile_cis_level1_workstation">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 24.04 Level 1 Workstation Benchmark [CUSTOMIZED]</title>
-    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 24.04 LTS Benchmark, v1.0.0, released 08-26-2024.</description>
+    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 24.04 LTS Benchmark, v1.0.0, released 2024-08-26.</description>
     <!--1.1.1.1: Ensure cramfs kernel module is not available (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_kernel_module_cramfs_disabled" selected="true"/>
     <!--1.1.1.2: Ensure freevxfs kernel module is not available (Automated)-->

--- a/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_1/tailoring/cis_level2_server-tailoring.xml
+++ b/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_1/tailoring/cis_level2_server-tailoring.xml
@@ -4,7 +4,7 @@
   <version time="1970-01-01T00:00:01+00:00">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level2_server_customized" extends="xccdf_org.ssgproject.content_profile_cis_level2_server">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 24.04 Level 2 Server Benchmark [CUSTOMIZED]</title>
-    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 24.04 LTS Benchmark, v1.0.0, released 08-26-2024.</description>
+    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 24.04 LTS Benchmark, v1.0.0, released 2024-08-26.</description>
     <!--1.1.1.1: Ensure cramfs kernel module is not available (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_kernel_module_cramfs_disabled" selected="true"/>
     <!--1.1.1.2: Ensure freevxfs kernel module is not available (Automated)-->

--- a/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_1/tailoring/cis_level2_workstation-tailoring.xml
+++ b/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_1/tailoring/cis_level2_workstation-tailoring.xml
@@ -4,7 +4,7 @@
   <version time="1970-01-01T00:00:01+00:00">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level2_workstation_customized" extends="xccdf_org.ssgproject.content_profile_cis_level2_workstation">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 24.04 Level 2 Workstation Benchmark [CUSTOMIZED]</title>
-    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 24.04 LTS Benchmark, v1.0.0, released 08-26-2024.</description>
+    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 24.04 LTS Benchmark, v1.0.0, released 2024-08-26.</description>
     <!--1.1.1.1: Ensure cramfs kernel module is not available (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_kernel_module_cramfs_disabled" selected="true"/>
     <!--1.1.1.2: Ensure freevxfs kernel module is not available (Automated)-->

--- a/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_2/tailoring/cis_level1_server-tailoring.xml
+++ b/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_2/tailoring/cis_level1_server-tailoring.xml
@@ -4,7 +4,7 @@
   <version time="1970-01-01T00:00:02+00:00">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level1_server_customized" extends="xccdf_org.ssgproject.content_profile_cis_level1_server">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 24.04 Level 1 Server Benchmark [CUSTOMIZED]</title>
-    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 24.04 LTS Benchmark, v1.0.0, released 08-26-2024.</description>
+    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 24.04 LTS Benchmark, v1.0.1, released in_the_future.</description>
     <!--1.1.1.1: Ensure cramfs kernel module is not available (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_kernel_module_cramfs_disabled" selected="true"/>
     <!--1.1.1.2: Ensure freevxfs kernel module is not available (Automated)-->

--- a/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_2/tailoring/cis_level1_workstation-tailoring.xml
+++ b/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_2/tailoring/cis_level1_workstation-tailoring.xml
@@ -4,7 +4,7 @@
   <version time="1970-01-01T00:00:02+00:00">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level1_workstation_customized" extends="xccdf_org.ssgproject.content_profile_cis_level1_workstation">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 24.04 Level 1 Workstation Benchmark [CUSTOMIZED]</title>
-    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 24.04 LTS Benchmark, v1.0.0, released 08-26-2024.</description>
+    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 24.04 LTS Benchmark, v1.0.1, released in_the_future.</description>
     <!--1.1.1.1: Ensure cramfs kernel module is not available (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_kernel_module_cramfs_disabled" selected="true"/>
     <!--1.1.1.2: Ensure freevxfs kernel module is not available (Automated)-->

--- a/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_2/tailoring/cis_level2_server-tailoring.xml
+++ b/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_2/tailoring/cis_level2_server-tailoring.xml
@@ -4,7 +4,7 @@
   <version time="1970-01-01T00:00:02+00:00">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level2_server_customized" extends="xccdf_org.ssgproject.content_profile_cis_level2_server">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 24.04 Level 2 Server Benchmark [CUSTOMIZED]</title>
-    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 24.04 LTS Benchmark, v1.0.0, released 08-26-2024.</description>
+    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 24.04 LTS Benchmark, v1.0.1, released in_the_future.</description>
     <!--1.1.1.1: Ensure cramfs kernel module is not available (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_kernel_module_cramfs_disabled" selected="true"/>
     <!--1.1.1.2: Ensure freevxfs kernel module is not available (Automated)-->

--- a/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_2/tailoring/cis_level2_workstation-tailoring.xml
+++ b/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_2/tailoring/cis_level2_workstation-tailoring.xml
@@ -4,7 +4,7 @@
   <version time="1970-01-01T00:00:02+00:00">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level2_workstation_customized" extends="xccdf_org.ssgproject.content_profile_cis_level2_workstation">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 24.04 Level 2 Workstation Benchmark [CUSTOMIZED]</title>
-    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 24.04 LTS Benchmark, v1.0.0, released 08-26-2024.</description>
+    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 24.04 LTS Benchmark, v1.0.1, released in_the_future.</description>
     <!--1.1.1.1: Ensure cramfs kernel module is not available (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_kernel_module_cramfs_disabled" selected="true"/>
     <!--1.1.1.2: Ensure freevxfs kernel module is not available (Automated)-->

--- a/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_3/tailoring/cis_level1_server-tailoring.xml
+++ b/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_3/tailoring/cis_level1_server-tailoring.xml
@@ -4,7 +4,7 @@
   <version time="1970-01-01T00:00:03+00:00">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level1_server_customized" extends="xccdf_org.ssgproject.content_profile_cis_level1_server">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 24.04 Level 1 Server Benchmark [CUSTOMIZED]</title>
-    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 24.04 LTS Benchmark, v1.0.0, released 08-26-2024.</description>
+    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 24.04 LTS Benchmark, v2.0.0, released in_the_future.</description>
     <!--1.1.1.1: Ensure cramfs kernel module is not available (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_kernel_module_cramfs_disabled" selected="true"/>
     <!--1.1.1.2: Ensure freevxfs kernel module is not available (Automated)-->

--- a/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_3/tailoring/cis_level1_workstation-tailoring.xml
+++ b/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_3/tailoring/cis_level1_workstation-tailoring.xml
@@ -4,7 +4,7 @@
   <version time="1970-01-01T00:00:03+00:00">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level1_workstation_customized" extends="xccdf_org.ssgproject.content_profile_cis_level1_workstation">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 24.04 Level 1 Workstation Benchmark [CUSTOMIZED]</title>
-    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 24.04 LTS Benchmark, v1.0.0, released 08-26-2024.</description>
+    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 24.04 LTS Benchmark, v2.0.0, released in_the_future.</description>
     <!--1.1.1.1: Ensure cramfs kernel module is not available (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_kernel_module_cramfs_disabled" selected="true"/>
     <!--1.1.1.2: Ensure freevxfs kernel module is not available (Automated)-->

--- a/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_3/tailoring/cis_level2_server-tailoring.xml
+++ b/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_CIS_3/tailoring/cis_level2_server-tailoring.xml
@@ -4,7 +4,7 @@
   <version time="1970-01-01T00:00:03+00:00">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level2_server_customized" extends="xccdf_org.ssgproject.content_profile_cis_level2_server">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 24.04 Level 2 Server Benchmark [CUSTOMIZED]</title>
-    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 24.04 LTS Benchmark, v1.0.0, released 08-26-2024.</description>
+    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 24.04 LTS Benchmark, v2.0.0, released in_the_future.</description>
     <!--1.1.1.1: Ensure cramfs kernel module is not available (Automated)-->
     <select idref="xccdf_org.ssgproject.content_rule_kernel_module_cramfs_disabled" selected="true"/>
     <!--1.1.1.2: Ensure freevxfs kernel module is not available (Automated)-->

--- a/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_STIG_1/tailoring/stig-tailoring.xml
+++ b/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_STIG_1/tailoring/stig-tailoring.xml
@@ -4,7 +4,7 @@
   <version time="1970-01-01T00:00:04+00:00">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_stig_customized" extends="xccdf_org.ssgproject.content_profile_stig">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">DISA-STIG Benchmark [CUSTOMIZED]</title>
-    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the DISA-STIG v.1, rel.1, released 2025-01-28.</description>
+    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the DISA-STIG V1R1, released 2025-01-28.</description>
     <!--UBTU-24-100010: Ubuntu 24.04 LTS must not have the "systemd-timesyncd" package installed.-->
     <select idref="xccdf_org.ssgproject.content_rule_package_timesyncd_removed" selected="true"/>
     <!--UBTU-24-100020: Ubuntu 24.04 LTS must not have the "ntp" package installed.-->

--- a/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_STIG_2/tailoring/stig-tailoring.xml
+++ b/tests/data/ubuntu2404/expected/benchmarks/ubuntu2404_STIG_2/tailoring/stig-tailoring.xml
@@ -4,7 +4,7 @@
   <version time="1970-01-01T00:00:05+00:00">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_stig_customized" extends="xccdf_org.ssgproject.content_profile_stig">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">DISA-STIG Benchmark [CUSTOMIZED]</title>
-    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the DISA-STIG v.1, rel.1, released 2025-01-28.</description>
+    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the DISA-STIG V1R3, released in_the_future.</description>
     <!--UBTU-24-100010: Ubuntu 24.04 LTS must not have the "systemd-timesyncd" package installed.-->
     <select idref="xccdf_org.ssgproject.content_rule_package_timesyncd_removed" selected="true"/>
     <!--UBTU-24-100020: Ubuntu 24.04 LTS must not have the "ntp" package installed.-->

--- a/tests/data/ubuntu2404/input/templates/tailoring/cis_level1_server-tailoring.xml
+++ b/tests/data/ubuntu2404/input/templates/tailoring/cis_level1_server-tailoring.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Tailoring xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_scap-workbench_tailoring_default">
-  <benchmark href="PLACEHOLDER"/>
-  <version time="PLACEHOLDER">1</version>
+  <benchmark href="${benchmark_href}"/>
+  <version time="${timestamp}">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level1_server_customized"
       extends="xccdf_org.ssgproject.content_profile_cis_level1_server">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 24.04 Level 1 Server Benchmark [CUSTOMIZED]</title>
-    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 24.04 LTS Benchmark, v1.0.0, released 08-26-2024.</description>
+    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 24.04 LTS Benchmark, ${benchmark_version}, released ${benchmark_release_date}.</description>
   </Profile>
 </Tailoring>

--- a/tests/data/ubuntu2404/input/templates/tailoring/cis_level1_server_ec2-tailoring.xml
+++ b/tests/data/ubuntu2404/input/templates/tailoring/cis_level1_server_ec2-tailoring.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Tailoring xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_scap-workbench_tailoring_default">
-  <benchmark href="PLACEHOLDER"/>
-  <version time="PLACEHOLDER">1</version>
+  <benchmark href="${benchmark_href}"/>
+  <version time="${timestamp}">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level1_server_ec2_customized"
       extends="xccdf_org.ssgproject.content_profile_cis_level1_server_ec2">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 24.04 Level 1 Server Benchmark - EC2 [CUSTOMIZED]</title>
-    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 24.04 LTS Benchmark, v1.0.0, released 08-26-2024. The EC2 profile is a strict subset of the Level 1 Server profile tailored for Amazon EC2 images.</description>
+    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 24.04 LTS Benchmark, ${benchmark_version}, released ${benchmark_release_date}. The EC2 profile is a strict subset of the Level 1 Server profile tailored for Amazon EC2 images.</description>
   </Profile>
 </Tailoring>

--- a/tests/data/ubuntu2404/input/templates/tailoring/cis_level1_workstation-tailoring.xml
+++ b/tests/data/ubuntu2404/input/templates/tailoring/cis_level1_workstation-tailoring.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Tailoring xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_scap-workbench_tailoring_default">
-  <benchmark href="PLACEHOLDER"/>
-  <version time="PLACEHOLDER">1</version>
+  <benchmark href="${benchmark_href}"/>
+  <version time="${timestamp}">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level1_workstation_customized"
       extends="xccdf_org.ssgproject.content_profile_cis_level1_workstation">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 24.04 Level 1 Workstation Benchmark [CUSTOMIZED]</title>
-    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 24.04 LTS Benchmark, v1.0.0, released 08-26-2024.</description>
+    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 24.04 LTS Benchmark, ${benchmark_version}, released ${benchmark_release_date}.</description>
   </Profile>
 </Tailoring>

--- a/tests/data/ubuntu2404/input/templates/tailoring/cis_level2_server-tailoring.xml
+++ b/tests/data/ubuntu2404/input/templates/tailoring/cis_level2_server-tailoring.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Tailoring xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_scap-workbench_tailoring_default">
-  <benchmark href="PLACEHOLDER"/>
-  <version time="PLACEHOLDER">1</version>
+  <benchmark href="${benchmark_href}"/>
+  <version time="${timestamp}">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level2_server_customized"
       extends="xccdf_org.ssgproject.content_profile_cis_level2_server">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 24.04 Level 2 Server Benchmark [CUSTOMIZED]</title>
-    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 24.04 LTS Benchmark, v1.0.0, released 08-26-2024.</description>
+    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 24.04 LTS Benchmark, ${benchmark_version}, released ${benchmark_release_date}.</description>
   </Profile>
 </Tailoring>

--- a/tests/data/ubuntu2404/input/templates/tailoring/cis_level2_workstation-tailoring.xml
+++ b/tests/data/ubuntu2404/input/templates/tailoring/cis_level2_workstation-tailoring.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Tailoring xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_scap-workbench_tailoring_default">
-  <benchmark href="PLACEHOLDER"/>
-  <version time="PLACEHOLDER">1</version>
+  <benchmark href="${benchmark_href}"/>
+  <version time="${timestamp}">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_cis_level2_workstation_customized"
       extends="xccdf_org.ssgproject.content_profile_cis_level2_workstation">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 24.04 Level 2 Workstation Benchmark [CUSTOMIZED]</title>
-    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 24.04 LTS Benchmark, v1.0.0, released 08-26-2024.</description>
+    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 24.04 LTS Benchmark, ${benchmark_version}, released ${benchmark_release_date}.</description>
   </Profile>
 </Tailoring>

--- a/tests/data/ubuntu2404/input/templates/tailoring/stig-tailoring.xml
+++ b/tests/data/ubuntu2404/input/templates/tailoring/stig-tailoring.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Tailoring xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_scap-workbench_tailoring_default">
-  <benchmark href="PLACEHOLDER"/>
-  <version time="PLACEHOLDER">1</version>
+  <benchmark href="${benchmark_href}"/>
+  <version time="${timestamp}">1</version>
   <Profile id="xccdf_org.ssgproject.content_profile_stig_customized"
       extends="xccdf_org.ssgproject.content_profile_stig">
     <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">DISA-STIG Benchmark [CUSTOMIZED]</title>
-    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the DISA-STIG v.1, rel.1, released 2025-01-28.</description>
+    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the DISA-STIG ${benchmark_version}, released ${benchmark_release_date}.</description>
   </Profile>
 </Tailoring>

--- a/tests/data/ubuntu2404/input/tools/release_metadata/noble_cis_benchmarks.yml
+++ b/tests/data/ubuntu2404/input/tools/release_metadata/noble_cis_benchmarks.yml
@@ -22,6 +22,7 @@ benchmark_releases:
           ComplianceAsCode implementation of CIS Ubuntu 24.04 LTS v1.0.1 benchmark.
       release_notes_url: https://github.com/canonical/ubuntu-security-guide/
       reference_url: https://www.cisecurity.org/benchmark/ubuntu_linux/
+      release_date: in_the_future
 
   - cac_tag: ubuntu2404_CIS_v2.0.0_24.04.8
     parent_tag: ubuntu2404_CIS_v2.0.0_24.04.7
@@ -43,6 +44,7 @@ benchmark_releases:
           ComplianceAsCode implementation of CIS Ubuntu 24.04 LTS v2.0.0 benchmark.
       release_notes_url: https://github.com/canonical/ubuntu-security-guide/
       reference_url: https://www.cisecurity.org/benchmark/ubuntu_linux/
+      release_date: in_the_future
 
   - cac_tag: ubuntu2404_CIS_v2.0.0_24.04.7
     parent_tag: ubuntu2404_CIS_v1.0.1_24.04.6
@@ -62,6 +64,7 @@ benchmark_releases:
           ComplianceAsCode implementation of CIS Ubuntu 24.04 LTS v2.0.0 benchmark.
       release_notes_url: https://github.com/canonical/ubuntu-security-guide/
       reference_url: https://www.cisecurity.org/benchmark/ubuntu_linux/
+      release_date: in_the_future
 
   - cac_tag: ubuntu2404_CIS_v1.0.1_24.04.6
     parent_tag: ubuntu2404_CIS_v1.0.1_24.04.5
@@ -81,6 +84,7 @@ benchmark_releases:
           ComplianceAsCode implementation of CIS Ubuntu 24.04 LTS v1.0.1 benchmark.
       release_notes_url: https://github.com/canonical/ubuntu-security-guide/
       reference_url: https://www.cisecurity.org/benchmark/ubuntu_linux/
+      release_date: in_the_future
 
   - cac_tag: ubuntu2404_CIS_v1.0.1_24.04.5
     parent_tag: ubuntu2404_CIS_v1.0.0.usg1_24.04.4
@@ -100,6 +104,7 @@ benchmark_releases:
           ComplianceAsCode implementation of CIS Ubuntu 24.04 LTS v1.0.1 benchmark.
       release_notes_url: https://github.com/canonical/ubuntu-security-guide/
       reference_url: https://www.cisecurity.org/benchmark/ubuntu_linux/
+      release_date: in_the_future
 
   - cac_tag: ubuntu2404_CIS_v1.0.0.usg1_24.04.4
     parent_tag: ubuntu2404_CIS_v1.0.0.usg1_24.04.3
@@ -119,6 +124,7 @@ benchmark_releases:
           ComplianceAsCode implementation of CIS Ubuntu 24.04 LTS v1.0.0 benchmark.
       release_notes_url: https://github.com/canonical/ubuntu-security-guide/
       reference_url: https://www.cisecurity.org/benchmark/ubuntu_linux/
+      release_date: in_the_future
 
   - cac_tag: ubuntu2404_CIS_v1.0.0.usg1_24.04.3
     parent_tag: ubuntu2404_CIS_v1.0.0_24.04.2
@@ -138,6 +144,7 @@ benchmark_releases:
           ComplianceAsCode implementation of CIS Ubuntu 24.04 LTS v1.0.0 benchmark.
       release_notes_url: https://github.com/canonical/ubuntu-security-guide/
       reference_url: https://www.cisecurity.org/benchmark/ubuntu_linux/
+      release_date: in_the_future
 
   - cac_tag: ubuntu2404_CIS_v1.0.0_24.04.2
     parent_tag: ubuntu2404_CIS_v1.0.0_24.04.1
@@ -157,6 +164,7 @@ benchmark_releases:
           ComplianceAsCode implementation of CIS Ubuntu 24.04 LTS v1.0.0 benchmark.
       release_notes_url: https://github.com/canonical/ubuntu-security-guide/
       reference_url: https://www.cisecurity.org/benchmark/ubuntu_linux/
+      release_date: 2024-08-26
 
   - cac_tag: ubuntu2404_CIS_v1.0.0_24.04.1
     parent_tag: 
@@ -176,4 +184,5 @@ benchmark_releases:
           ComplianceAsCode implementation of CIS Ubuntu 24.04 LTS v1.0.0 benchmark.
       release_notes_url: https://github.com/canonical/ubuntu-security-guide/
       reference_url: https://www.cisecurity.org/benchmark/ubuntu_linux/
+      release_date: 2024-08-26
 

--- a/tests/data/ubuntu2404/input/tools/release_metadata/noble_stig_benchmarks.yml
+++ b/tests/data/ubuntu2404/input/tools/release_metadata/noble_stig_benchmarks.yml
@@ -19,6 +19,7 @@ benchmark_releases:
           ComplianceAsCode implementation of STIG Ubuntu 24.04 LTS V1R3 benchmark.
       release_notes_url: https://github.com/canonical/ubuntu-security-guide/
       reference_url: https://public.cyber.mil/stigs/downloads/
+      release_date: in_the_future
 
   - cac_tag: ubuntu2404_STIG_V1R2_24.04.6
     parent_tag: ubuntu2404_STIG_V1R1_24.04.5
@@ -35,6 +36,7 @@ benchmark_releases:
           ComplianceAsCode implementation of STIG Ubuntu 24.04 LTS V1R2 benchmark.
       release_notes_url: https://github.com/canonical/ubuntu-security-guide/
       reference_url: https://public.cyber.mil/stigs/downloads/
+      release_date: in_the_future
 
   - cac_tag: ubuntu2404_STIG_V1R1_24.04.5
     parent_tag: 
@@ -51,3 +53,4 @@ benchmark_releases:
           ComplianceAsCode implementation of STIG Ubuntu 24.04 LTS V1R1 benchmark.
       release_notes_url: https://github.com/canonical/ubuntu-security-guide/
       reference_url: https://public.cyber.mil/stigs/downloads/
+      release_date: 2025-01-28

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -134,6 +134,7 @@ def test_channel_data(test_metadata):
     metadata = Metadata.from_json(test_metadata)
     channel = metadata.channels["ubuntu2404_CIS_2"]
     assert channel.benchmark_ids == ["ubuntu2404_CIS_2-v1.0.0.usg1", "ubuntu2404_CIS_2-v1.0.1"]
+    assert channel.latest_benchmark_id == "ubuntu2404_CIS_2-v1.0.1"
     assert channel.channel_number == 2
     assert channel.is_latest == False
     assert metadata.channels["ubuntu2404_CIS_3"].is_latest == True
@@ -146,7 +147,7 @@ def test_channel_data(test_metadata):
     assert channel.release_timestamp == 2
     assert channel.tailoring_files["cis_level2_server"] == {
         "path": "ubuntu2404_CIS_2/tailoring/cis_level2_server-tailoring.xml",
-        "sha256": "a47d4e557e7c3a3e0fa14f320a2550db2a9ed52766239e11fedb6bf56273b578",
+        "sha256": "4c2cd791c54e5fb85e5d6ea5201ec1974d6529cb2e18dfbfde0e9b1621ed0bbc",
     }
     t_rel_path = channel.get_tailoring_file_relative_path("cis_level2_server")
     assert t_rel_path == Path(

--- a/tools/generate_tailoring_file.py
+++ b/tools/generate_tailoring_file.py
@@ -29,6 +29,7 @@ import datetime
 import logging
 import subprocess
 from pathlib import Path
+from string import Template
 
 from cac_tools import CaCProfile
 from lxml import etree
@@ -48,6 +49,8 @@ def generate_tailoring_file(
     benchmark_id: str,
     tailoring_file_output_path: Path,
     timestamp: float,
+    benchmark_version: str,
+    benchmark_release_date: str
 ) -> None:
     """Create a tailoring file based on provided args.
 
@@ -58,7 +61,8 @@ def generate_tailoring_file(
         benchmark_id: benchmark ID (e.g. ubuntu2404_CIS_1)
         tailoring_file_output_path: output path
         timestamp: timestamp to be used in "time" attribute
-
+        title: benchmark title
+        description: benchmark description
     Raises:
         GenerateTailoringError
 
@@ -78,26 +82,27 @@ def generate_tailoring_file(
         timestamp,
         datetime.timezone.utc
         ).isoformat()
+    benchmark_href = BENCHMARK_HREF_PATTERN.format(benchmark_id=benchmark_id)
 
     try:
+        logger.debug(f"Parsing datastream file {datastream_path}")
         datastream_doc = etree.parse(datastream_path)
     except etree.XMLSyntaxError as e:
         raise GenerateTailoringError(f"Failed to process datastream file: {e}") from e
-
     try:
         logger.debug(f"Processing template tailoring file {tailoring_template_path}")
-        parser = etree.XMLParser(remove_blank_text=True)
-        tailor_doc = etree.parse(tailoring_template_path, parser)
-        xml_bench = tailor_doc.find(f".//{{{XMLNS}}}benchmark")
-        xml_bench.attrib["href"] = BENCHMARK_HREF_PATTERN.format(
-            benchmark_id=benchmark_id
+        tailoring_template = Template(tailoring_template_path.read_text()).substitute(
+            benchmark_href=benchmark_href,
+            timestamp=iso_timestamp,
+            benchmark_version=benchmark_version,
+            benchmark_release_date=benchmark_release_date
         )
-        xml_ver = tailor_doc.find(f".//{{{XMLNS}}}version")
-        xml_ver.attrib["time"] = iso_timestamp
-    except etree.XMLSyntaxError as e:
+        parser = etree.XMLParser(remove_blank_text=True)
+        tailor_doc = etree.fromstring(tailoring_template.encode(), parser).getroottree()
+    except Exception as e:
         raise GenerateTailoringError(
             f"Failed to process template tailoring file: {e}"
-            ) from e
+        ) from e
 
     logger.debug(f"Mapping rules and variables to controls for profile {profile_path}")
     control_map = {cid: {"rules": [], "vars": []} for cid in profile.controls}
@@ -204,6 +209,8 @@ if __name__ == "__main__":
         "tailoring_template_path", type=Path, help="Path to tailoring template file"
     )
     argparser.add_argument("benchmark_id", type=str, help="Benchmark ID")
+    argparser.add_argument("benchmark_version", type=str, help="Benchmark version")
+    argparser.add_argument("benchmark_release_date", type=str, help="Benchmark release date")
     argparser.add_argument(
         "output_tailoring_path", type=Path, help="Path to output tailoring file"
     )
@@ -221,6 +228,8 @@ if __name__ == "__main__":
         f"tailoring template {args.tailoring_template_path}"
     )
     logger.info(f"Benchmark ID: {args.benchmark_id}")
+    logger.info(f"Benchmark Version: {args.benchmark_version}")
+    logger.info(f"Benchmark Release Date: {args.benchmark_release_date}")
     logger.info(f"Output tailoring file: {args.output_tailoring_path}")
 
     try:
@@ -231,6 +240,8 @@ if __name__ == "__main__":
             args.benchmark_id,
             args.output_tailoring_path,
             time.time(),
+            args.benchmark_version,
+            args.benchmark_release_date
         )
         validate_tailoring_file(args.output_tailoring_path)
     except GenerateTailoringError as e:

--- a/tools/process_benchmarks.py
+++ b/tools/process_benchmarks.py
@@ -77,7 +77,7 @@ def _get_release_channel_successions(
     logger.debug("Entered get_release_successions()")
 
     # sanity check tailoring versions (channels) (should be all from 1 to max())
-    channels = sorted({r["release_channel"] for r in all_releases})
+    channels = sorted({int(r["release_channel"]) for r in all_releases})
     channels_good = list(range(1, max(channels) + 1))
     if channels != channels_good:
         raise BenchmarkProcessingError(
@@ -88,7 +88,7 @@ def _get_release_channel_successions(
     # bin by channel_id
     releases_by_channels = {channel: [] for channel in channels}
     for release in all_releases:
-        channel = release["release_channel"]
+        channel = int(release["release_channel"])
         releases_by_channels[channel].append(release)
 
     # sort by release (first to latest) and sanity checks
@@ -169,26 +169,31 @@ def _process_yaml(yaml_data: dict[str, Any]) -> tuple[dict[str, Any], dict[str, 
     benchmark_type = yaml_data["general"]["benchmark_type"]
     latest_release = list(releases_by_channels.values())[-1][-1]
     latest_version = latest_release["benchmark_data"]["version"]
-    latest_channel_number = latest_release["release_channel"]
+    latest_channel_number = int(latest_release["release_channel"])
     latest_channel_id = f"{product}_{benchmark_type}_{latest_channel_number}"
     latest_benchmark_id = f"{latest_channel_id}-{latest_version}"
 
     # Add info from latest releases in each channel to 'channel_data'
     for channel_number, releases_in_channel in releases_by_channels.items():
 
-        latest_release = releases_in_channel[-1]
+        latest_release_in_channel = releases_in_channel[-1]
         channel_id = f"{product}_{benchmark_type}_{channel_number}"
         assert channel_id not in release_channels
+        
+        latest_benchmark_version_in_channel = latest_release_in_channel["benchmark_data"]["version"]
+        latest_benchmark_id_in_channel = f"{channel_id}-{latest_benchmark_version_in_channel}"
+
         release_channels[channel_id] = {
             "id": channel_id,
+            "latest_benchmark_id": latest_benchmark_id_in_channel,
             "benchmark_ids": [], # populated below
             "channel_number": channel_number,
             "is_latest": channel_number == latest_channel_number,
             "cac_product": product,
-            "cac_profiles": list(latest_release["benchmark_data"]["profiles"]), # store profiles here to ensure all benchmarks in one channel have same profiles
-            "release_tag": latest_release["cac_tag"],
-            "release_commit": latest_release["cac_commit"],
-            "release_notes_url": latest_release["benchmark_data"]["release_notes_url"],
+            "cac_profiles": list(latest_release_in_channel["benchmark_data"]["profiles"]), # store profiles in the channel dict to ensure all benchmarks in one channel have same profiles
+            "release_tag": latest_release_in_channel["cac_tag"],
+            "release_commit": latest_release_in_channel["cac_commit"],
+            "release_notes_url": latest_release_in_channel["benchmark_data"]["release_notes_url"],
             "release_timestamp": None, # added at build time
             "data_files": None, # added at build time
             "tailoring_files": None, # added at build time
@@ -319,7 +324,6 @@ def _process_yaml(yaml_data: dict[str, Any]) -> tuple[dict[str, Any], dict[str, 
             latest_breaking_id = None
         profile["latest_breaking_id"] = latest_breaking_id
 
-
     for s in ["profiles", "benchmarks", "release_channels"]:
         logger.debug(f"---{s}---")
         for k, v in locals()[s].items():
@@ -423,7 +427,9 @@ def _create_tailoring_file(
         tailoring_template_path: Path,
         benchmark_id: str,
         output_tailoring_path: Path,
-        release_timestamp: int
+        release_timestamp: int,
+        benchmark_version: str,
+        benchmark_release_date: str
 ) -> None:
     # Generate and validate tailoring file
     if not profile_path.exists():
@@ -442,7 +448,9 @@ def _create_tailoring_file(
             tailoring_template_path,
             benchmark_id,
             output_tailoring_path,
-            release_timestamp
+            release_timestamp,
+            benchmark_version,
+            benchmark_release_date
         )
         validate_tailoring_file(output_tailoring_path)
     except GenerateTailoringError as e:
@@ -460,7 +468,7 @@ def _calc_sha256(path: Path) -> str:
 
 
 def _build_active_releases(
-    release_channels: list[dict[str, Any]],
+    release_data: dict[str, list[dict[str, Any]]],
     cac_repo_dir: Path,
     tailoring_templates_dir: Path,
     dst_dir: Path,
@@ -471,6 +479,8 @@ def _build_active_releases(
     # - generate tailoring files
     # - generate checksums
 
+    release_channels = release_data["release_channels"]
+    
     logger.info(f"Building {len(release_channels)} active releases...")
 
     for i, channel_data in enumerate(release_channels):
@@ -571,8 +581,14 @@ def _build_active_releases(
                 shutil.copy(sce_script, sce_dst_path)
                 sce_dst_path.chmod(0o755)  # SCEs must be executable
 
+            # Get the version and release_date of the latest benchmark in the channel
+            latest_benchmark_id = channel_data["latest_benchmark_id"]
+            latest_benchmark = [b for b in release_data["benchmarks"] if b["id"] == latest_benchmark_id][0]
+            benchmark_version = latest_benchmark["version"]
+            benchmark_release_date = latest_benchmark["release_date"]
+
             # Generate tailoring files
-            logger.debug("Generating tailoring files for benchmark {benchmark_id}...")
+            logger.debug(f"Generating tailoring files for benchmark {latest_benchmark_id}...")
             output_tailoring_files_dir = output_benchmark_dir / "tailoring"
             output_tailoring_files_dir.mkdir()
             channel_data["tailoring_files"] = {}
@@ -597,7 +613,9 @@ def _build_active_releases(
                     tailoring_template_path,
                     channel_id,
                     output_tailoring_path,
-                    release_timestamp
+                    release_timestamp,
+                    benchmark_version,
+                    benchmark_release_date
                 )
 
                 # Calc hashes and set metadata
@@ -653,7 +671,7 @@ def process_benchmarks(
     for benchmark_yaml in sorted(benchmark_yaml_files):
         logger.info(f"Processing yaml - {benchmark_yaml}")
         with Path(benchmark_yaml).open() as f:
-            yaml_data = yaml.safe_load(f.read())
+            yaml_data = yaml.load(f.read(), Loader=yaml.BaseLoader)
 
         # sanity checks
         for k in ["general", "benchmark_releases"]:
@@ -684,7 +702,7 @@ def process_benchmarks(
     with tempfile.TemporaryDirectory() as tmp_dst_dir:
         logger.info(f"Building benchmark data in {tmp_dst_dir}")
         _build_active_releases(
-            benchmarks_json_data["release_channels"],
+            benchmarks_json_data,
             cac_repo_dir,
             tailoring_templates_dir,
             Path(tmp_dst_dir),

--- a/tools/process_benchmarks.py
+++ b/tools/process_benchmarks.py
@@ -357,7 +357,7 @@ def _build_cac_release(cac_repo_dir: Path, commit: str, cac_product: str) -> int
             logger.debug(f"STDOUT: {p.stdout}")
             logger.debug(f"STDERR: {p.stderr}")
         except subprocess.CalledProcessError as e:
-            logger.error(p.stderr)
+            logger.error(e.stderr)
             raise BenchmarkProcessingError(
                 f"Failed to checkout commit {commit} in repo {cac_repo_dir}: {e}"
                 ) from e

--- a/tools/release_metadata/jammy_cis_benchmarks.yml
+++ b/tools/release_metadata/jammy_cis_benchmarks.yml
@@ -3,6 +3,21 @@ general:
   product: ubuntu2204
   product_long: Ubuntu 22.04 LTS (Jammy Jellyfish)
 benchmark_releases:
+- cac_tag: jammy-cis-2.3
+  parent_tag: jammy-cis-2.2
+  release_channel: 2
+  cac_commit: d69cc25533b9cee2cbab5f88aee2b53bf7538fd1
+  usg_version: 22.04.18
+  benchmark_data:
+    version: v2.0.0
+    profiles:
+      cis_level1_server: {}
+      cis_level2_server: {}
+      cis_level1_workstation: {}
+      cis_level2_workstation: {}
+    description: ComplianceAsCode implementation of CIS Ubuntu 22.04 LTS v2.0.0 benchmark.
+    release_notes_url: https://github.com/canonical/ubuntu-security-guide/pull/122
+    reference_url: https://www.cisecurity.org/benchmark/ubuntu_linux/
 - cac_tag: jammy-cis-2.2
   parent_tag: jammy-cis-2.1
   release_channel: 2

--- a/tools/release_metadata/jammy_cis_benchmarks.yml
+++ b/tools/release_metadata/jammy_cis_benchmarks.yml
@@ -18,6 +18,7 @@ benchmark_releases:
     description: ComplianceAsCode implementation of CIS Ubuntu 22.04 LTS v2.0.0 benchmark.
     release_notes_url: https://github.com/canonical/ubuntu-security-guide/pull/122
     reference_url: https://www.cisecurity.org/benchmark/ubuntu_linux/
+    release_date: 2024-03-28
 - cac_tag: jammy-cis-2.2
   parent_tag: jammy-cis-2.1
   release_channel: 2
@@ -33,6 +34,7 @@ benchmark_releases:
     description: ComplianceAsCode implementation of CIS Ubuntu 22.04 LTS v2.0.0 benchmark.
     release_notes_url: https://github.com/canonical/ubuntu-security-guide/pull/118
     reference_url: https://www.cisecurity.org/benchmark/ubuntu_linux/
+    release_date: 2024-03-28
 - cac_tag: jammy-cis-1.15
   parent_tag: jammy-cis-1.14
   release_channel: 1
@@ -49,6 +51,7 @@ benchmark_releases:
     description: ComplianceAsCode implementation of CIS Ubuntu 22.04 LTS v1.0.0 benchmark.
     release_notes_url: https://github.com/canonical/ubuntu-security-guide/pull/118
     reference_url: https://www.cisecurity.org/benchmark/ubuntu_linux/
+    release_date: 2022-08-30
 - cac_tag: jammy-cis-2.1
   parent_tag: jammy-cis-1.14
   release_channel: 2
@@ -64,6 +67,7 @@ benchmark_releases:
     description: ComplianceAsCode implementation of CIS Ubuntu 22.04 LTS v2.0.0 benchmark.
     release_notes_url: https://github.com/canonical/ubuntu-security-guide/pull/105
     reference_url: https://www.cisecurity.org/benchmark/ubuntu_linux/
+    release_date: 2024-03-28
 - cac_tag: jammy-cis-1.14
   parent_tag: jammy-cis-1.13
   release_channel: 1
@@ -80,6 +84,7 @@ benchmark_releases:
     description: ComplianceAsCode implementation of CIS Ubuntu 22.04 LTS v1.0.0 benchmark.
     release_notes_url: https://github.com/canonical/ubuntu-security-guide/pull/105
     reference_url: https://www.cisecurity.org/benchmark/ubuntu_linux/
+    release_date: 2022-08-30
 - cac_tag: jammy-cis-1.13
   parent_tag: jammy-cis-1.12
   release_channel: 1
@@ -96,6 +101,7 @@ benchmark_releases:
     description: ComplianceAsCode implementation of CIS Ubuntu 22.04 LTS v1.0.0 benchmark.
     release_notes_url: https://github.com/canonical/ubuntu-security-guide/pull/72
     reference_url: https://www.cisecurity.org/benchmark/ubuntu_linux/
+    release_date: 2022-08-30
 - cac_tag: jammy-cis-1.12
   parent_tag: null
   release_channel: 1
@@ -112,3 +118,4 @@ benchmark_releases:
     description: ComplianceAsCode implementation of CIS Ubuntu 22.04 LTS v1.0.0 benchmark.
     release_notes_url: https://github.com/canonical/ubuntu-security-guide/pull/72
     reference_url: https://www.cisecurity.org/benchmark/ubuntu_linux/
+    release_date: 2022-08-30

--- a/tools/release_metadata/jammy_stig_benchmarks.yml
+++ b/tools/release_metadata/jammy_stig_benchmarks.yml
@@ -15,6 +15,7 @@ benchmark_releases:
     description: ComplianceAsCode implementation of STIG Ubuntu 22.04 LTS V2R3 benchmark.
     release_notes_url: https://github.com/canonical/ubuntu-security-guide/pull/118
     reference_url: https://public.cyber.mil/stigs/downloads/
+    release_date: 2025-01-30
 - cac_tag: jammy-stig-1.7
   parent_tag: jammy-stig-1.6
   release_channel: 1
@@ -27,6 +28,7 @@ benchmark_releases:
     description: ComplianceAsCode implementation of STIG Ubuntu 22.04 LTS V2R3 benchmark.
     release_notes_url: https://github.com/canonical/ubuntu-security-guide/pull/105
     reference_url: https://public.cyber.mil/stigs/downloads/
+    release_date: 2025-01-30
 - cac_tag: jammy-stig-1.6
   parent_tag: jammy-stig-1.5
   release_channel: 1
@@ -39,6 +41,7 @@ benchmark_releases:
     description: ComplianceAsCode implementation of STIG Ubuntu 22.04 LTS V2R3 benchmark.
     release_notes_url: https://github.com/canonical/ubuntu-security-guide/pull/72
     reference_url: https://public.cyber.mil/stigs/downloads/
+    release_date: 2025-01-30
 - cac_tag: jammy-stig-1.5
   parent_tag: null
   release_channel: 1
@@ -51,3 +54,4 @@ benchmark_releases:
     description: ComplianceAsCode implementation of STIG Ubuntu 22.04 LTS V2R3 benchmark.
     release_notes_url: https://github.com/canonical/ubuntu-security-guide/pull/72
     reference_url: https://public.cyber.mil/stigs/downloads/
+    release_date: 2025-01-30


### PR DESCRIPTION
## Release info
- Minor fixes and improvements to CaC content
- Fixed benchmark version and release date in tailoring files

## Changelog

  * CaC content - CIS v2.0.0:
    - Fix /var/log ownership rules to account for non-shell accounts (LP: #2142301)
    - Improve chronyd_configure_pool_and_server rule to add trailing newline (LP: #2141667)
    - Fix incorrect username parsing in file_owner template (LP: #2137602)
  * USG tool:
    - Fix benchmark version and release date in tailoring files (LP: #2142286)
 