### PR TITLE
Version 22.04.19

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-security-guides-enhanced (22.04.19) jammy; urgency=medium
+
+  * CaC content - New profile for DISA STIG v2r8 (stig-v2r8)
+
+ -- Miha Purg <miha.purg@canonical.com>  Tue, 19 May 2026 09:25:21 +0200
+
 ubuntu-security-guides-enhanced (22.04.18) jammy; urgency=medium
 
   * CaC content - CIS v2.0.0:

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 # pyproject.toml (PEP 621) is not supported in setuptools < 61
 [metadata]
 name = usg
-version = 22.04.18
+version = 22.04.19
 
 [options]
 packages = find:

--- a/tools/release_metadata/jammy_cis_benchmarks.yml
+++ b/tools/release_metadata/jammy_cis_benchmarks.yml
@@ -3,6 +3,23 @@ general:
   product: ubuntu2204
   product_long: Ubuntu 22.04 LTS (Jammy Jellyfish)
 benchmark_releases:
+- cac_tag: jammy-cis-1.16
+  parent_tag: jammy-cis-1.15
+  release_channel: 1
+  cac_commit: ae1ef41a4e9fd5b092df4974670c5f951158e965
+  usg_version: 22.04.19
+  benchmark_data:
+    version: v1.0.0
+    profiles:
+      cis_level1_server: {}
+      cis_level1_server_ec2: {}
+      cis_level2_server: {}
+      cis_level1_workstation: {}
+      cis_level2_workstation: {}
+    description: ComplianceAsCode implementation of CIS Ubuntu 22.04 LTS v1.0.0 benchmark.
+    release_notes_url: https://github.com/canonical/ubuntu-security-guide/pull/124
+    reference_url: https://www.cisecurity.org/benchmark/ubuntu_linux/
+    release_date: 2022-08-30
 - cac_tag: jammy-cis-2.3
   parent_tag: jammy-cis-2.2
   release_channel: 2

--- a/tools/release_metadata/jammy_stig_benchmarks.yml
+++ b/tools/release_metadata/jammy_stig_benchmarks.yml
@@ -3,6 +3,19 @@ general:
   product: ubuntu2204
   product_long: Ubuntu 22.04 LTS (Jammy Jellyfish)
 benchmark_releases:
+- cac_tag: jammy-stig-1.9
+  parent_tag: jammy-stig-1.8
+  release_channel: 1
+  cac_commit: e60393aa18d8a0920925bb1e28fb95a6952737e1
+  usg_version: 22.04.19
+  benchmark_data:
+    version: V2R3
+    profiles:
+      stig: {}
+    description: ComplianceAsCode implementation of STIG Ubuntu 22.04 LTS V2R3 benchmark.
+    release_notes_url: https://github.com/canonical/ubuntu-security-guide/pull/124
+    reference_url: https://public.cyber.mil/stigs/downloads/
+    release_date: 2025-01-30
 - cac_tag: jammy-stig-2.1
   parent_tag: jammy-stig-1.8
   release_channel: 2

--- a/tools/release_metadata/jammy_stig_benchmarks.yml
+++ b/tools/release_metadata/jammy_stig_benchmarks.yml
@@ -3,6 +3,19 @@ general:
   product: ubuntu2204
   product_long: Ubuntu 22.04 LTS (Jammy Jellyfish)
 benchmark_releases:
+- cac_tag: jammy-stig-2.1
+  parent_tag: jammy-stig-1.8
+  release_channel: 2
+  cac_commit: af68ca3f5f38319f760468404faafd6a15c87ed6
+  usg_version: 22.04.19
+  benchmark_data:
+    version: V2R8
+    profiles:
+      stig: {}
+    description: ComplianceAsCode implementation of STIG Ubuntu 22.04 LTS V2R8 benchmark.
+    release_notes_url: https://github.com/canonical/ubuntu-security-guide/pull/124
+    reference_url: https://public.cyber.mil/stigs/downloads/
+    release_date: 2025-01-30
 - cac_tag: jammy-stig-1.8
   parent_tag: jammy-stig-1.7
   release_channel: 1


### PR DESCRIPTION
## Release info
- Added the new profile for Ubuntu 22.04 STIG V2R8: `stig-v2r8`. The profile is not backwards compatible with the previous STIG profiles - tailoring files need to be recreated and re-evaluated. See [migration guide](https://discourse.ubuntu.com/t/usg-profile-migration-from-stig-v2r3-to-v2r8/83473) for more information.

